### PR TITLE
Android notifications use "clickAction" instead of "url"

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ automation:
           url: >-
             https://fr24.com/{{ trigger.event.data.callsign }}/{{
             trigger.event.data.id }}
+          clickAction: >-
+            https://fr24.com/{{ trigger.event.data.callsign }}/{{
+            trigger.event.data.id }}
           image: "{{ trigger.event.data.aircraft_photo_medium }}"
 ```
 
@@ -149,6 +152,9 @@ automation:
           [Open FlightRadar](https://www.flightradar24.com/{{ trigger.event.data.callsign }})
         data:
           url: >-
+            https://fr24.com/{{ trigger.event.data.callsign }}/{{
+            trigger.event.data.id }}
+          clickAction: >-
             https://fr24.com/{{ trigger.event.data.callsign }}/{{
             trigger.event.data.id }}
           image: "{{ trigger.event.data.aircraft_photo_medium }}"


### PR DESCRIPTION
I'm updating the README.md to add "clickAction" to the notifications, because that's what makes a notification clickable on Android.

Also, Android doesn't render Markdown in the notifications. I don't know about iOS. But I didn't make changes there, so I would also highlight that removing Markdown on the notification message would make it appear cleaner on Android.