### PR TITLE
Fix for closest_distance (#161)

### DIFF
--- a/custom_components/flightradar24/coordinator.py
+++ b/custom_components/flightradar24/coordinator.py
@@ -266,9 +266,8 @@ class FlightRadar24Coordinator(DataUpdateCoordinator[int]):
             flight['squawk'] = obj.squawk
             flight['vertical_speed'] = obj.vertical_speed
             new_distance = obj.get_distance_from(self.point)
-            prev_distance = flight.get('distance', None) or new_distance
             flight['distance'] = new_distance
-            flight['closest_distance'] = min(new_distance, prev_distance)
+            flight['closest_distance'] = min(new_distance, flight.get('closest_distance', new_distance))
             flight['on_ground'] = obj.on_ground
             self._takeoff_and_landing(flight, last_position, obj.on_ground, sensor_type)
 


### PR DESCRIPTION
It should compare the new value to the current value of closest_distance, and not to the previous recorded value because that one might be higher than closest_distance