### PR TITLE
Docs: Add Flightradar custom card mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,14 @@ cards:
     aspect_ratio: 100%
 ```
 
+### Custom Lovelace Card
+
+There is also a custom card developed by the community:
+
+**[Flightradar Flight Card](https://github.com/plckr/flightradar-flight-card)** by [@plckr](https://github.com/plckr)
+
+![Flightradar Flight Card](https://raw.githubusercontent.com/plckr/flightradar-flight-card/refs/heads/main/card-examples/area-card-light.png)
+
 ## Database decrease
 To decrease data stored by [Recorder](https://www.home-assistant.io/integrations/recorder/) in database add following lines to your `configuration.yaml` file:
 ```yaml


### PR DESCRIPTION
Developed a custom card to use this integration, I'm suggesting to add the card into the README of your custom integration.

[Flightradar Custom Card](https://github.com/plckr/flightradar-flight-card)

Let me know if you want me to change anything.