### PR TITLE
Fix airport switching fetching wrong data + add immediate sensor refresh on track change

### DIFF
--- a/custom_components/flightradar24/api/airport.py
+++ b/custom_components/flightradar24/api/airport.py
@@ -67,7 +67,7 @@ class AirportProcessor:
         if not self._code and not code:
             return
 
-        data = get_value(self._client.get_airport_details(self._code or code), ['airport', 'pluginData'])
+        data = get_value(self._client.get_airport_details(code or self._code), ['airport', 'pluginData'])
         self._stats = AirportStats()
         stats = get_value(data, ['details', 'stats', 'arrivals'])
         self._stats.arrivals_on_time = to_int(get_value(stats, ['today', 'quantity', 'onTime']))

--- a/custom_components/flightradar24/coordinator.py
+++ b/custom_components/flightradar24/coordinator.py
@@ -81,6 +81,9 @@ class FlightRadar24Coordinator(DataUpdateCoordinator[int]):
                 await self.hass.async_add_executor_job(self.airport.set_track, code)
         except Exception as e:
             self.logger.error("FlightRadar24: %s", e)
+            return
+
+        self.async_set_updated_data(self.data)
 
     async def _async_update_data(self):
         if not self.scanning:


### PR DESCRIPTION
## Summary

Two bugs in the airport tracking feature, both reproducible on v1.32.2.

---

### Bug 1: Switching airports fetches the previous airport's data

**File:** `api/airport.py`, line 70

`set_track()` calls `update_airport_info(code)` *before* updating `self._code`:

```python
def set_track(self, code: str) -> None:
    code = code.upper()
    self.update_airport_info(code)  # self._code still holds the OLD value here
    self._code = code               # updated after
```

With `self._code or code`, if `_code` is already set (e.g. `"LTN"`), the expression always evaluates to the old code — so switching from LTN to STN silently fetches LTN's data again.

**Fix:** swap operand order to `code or self._code` so the explicitly passed code takes precedence.

---

### Bug 2: Sensors do not refresh immediately after changing the airport track

**File:** `coordinator.py`, `update_airport_track()`

After a successful `set_track()` call, `async_set_updated_data()` is never called, so all airport sensors show stale data until the next scheduled poll. The airport selector appears broken until the background refresh fires.

**Fix:** call `self.async_set_updated_data(self.data)` on success, and `return` early on exception so the refresh is not triggered after a failure.

---

## Testing

Both fixes verified locally on HA 2026.2.3 with v1.32.2. Switching airports now immediately updates all airport sensors with the correct airport's data.