### PR TITLE
Hotfix: Resolve 403 Forbidden errors via iOS Header Spoofing & Optional Cloudflare Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 [![HACS](https://img.shields.io/badge/HACS-Default-orange.svg?logo=HomeAssistantCommunityStore&logoColor=white)](https://github.com/hacs/integration)
 [![Community Forum](https://img.shields.io/static/v1.svg?label=Community&message=Forum&color=41bdf5&logo=HomeAssistant&logoColor=white)](https://community.home-assistant.io/t/custom-component-flightradar24)
 
+> [!WARNING]
+> **Connection Issue (403 Forbidden)**: Flightradar24 is currently blocking direct connections from Home Assistant IP addresses.
+> To fix this, you must set up a **Cloudflare Worker Proxy** to bypass the block.
+> * **Solution**: Use a personal proxy to bypass Cloudflare bot detection.
+> * **Guide**: Follow the [Troubleshooting guide](#-troubleshooting-resolving-403-forbidden-errors) at the bottom of this page.
+> * **Configuration**: Paste your Worker URL into the "Cloudflare Proxy URL" field in the integration settings.
+
 Flightradar24 integration allows one to track overhead flights in a given region or particular planes. It will also fire Home Assistant events when flights enter/exit/landed/took off. Or monitor departures and arrivals at an airport
 
 <b>IMPORTANT: No need FlightRadar24 subscription!</b>
@@ -475,6 +482,28 @@ Sensor `sensor.flightradar24_airport_arrivals` and `sensor.flightradar24_airport
 | time_real_arrival | Real arrival time |
 | time_estimated_departure | Estimated departure time |
 | time_estimated_arrival | Estimated arrival time |
+
+## 🛠️ Troubleshooting: Resolving 403 Forbidden Errors
+If you are receiving `403 Forbidden` errors in your logs, Flightradar24 is likely blocking your IP. You can bypass this by setting up a personal **Cloudflare Worker Proxy**.
+
+### Step 1: Deploy the Cloudflare Worker
+1. Click this [**1-Step Deploy Link**](https://deploy.workers.cloudflare.com/?url=https://github.com/DimaD16/cloudflare-workers-fr24-proxy/tree/main) (provided by @DimaD16).
+2. Log into your Cloudflare account.
+3. **Crucial:** Change the pre-entered project name to something unique that you will recognize.
+4. Click **Deploy**.
+
+### Step 2: Retrieve your Proxy URL
+1. After deployment is complete, click the blue **Visit** button in the top right corner.
+2. A new tab will open. **Copy the URL** from your browser's address bar (e.g., `https://your-unique-name.your-subdomain.workers.dev`).
+
+### Step 3: Configure the Integration
+1. In Home Assistant, go to **Settings** > **Devices & Services** > **Flightradar24**.
+2. Click **Configure**.
+3. Paste your URL into the **Cloudflare Proxy URL (Optional)** field.
+4. Click **Submit**.
+
+> [!TIP]
+> The integration automatically handles the URL formatting. You can paste the base URL directly, and the code will append the necessary parameters.
 
 ## Thanks To
  - [FlightRadarAPI](https://github.com/JeanExtreme002/FlightRadarAPI) by [@JeanExtreme002](https://github.com/JeanExtreme002)

--- a/custom_components/flightradar24/__init__.py
+++ b/custom_components/flightradar24/__init__.py
@@ -38,17 +38,20 @@ PLATFORMS: list[Platform] = [
 _LOGGER = getLogger(__name__)
 
 
+Python
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
     proxy_url = entry.data.get(CONF_PROXY_URL)
 
-    # iOS Spoofing Headers
-    Core.headers = {
-        "accept-encoding": "gzip, br",
-        "accept-language": "en-US,en;q=0.9",
-        "cache-control": "max-age=0",
+    # UPDATED: We only change the User-Agent, keeping all other original headers
+    Core.headers.update({
         "user-agent": "Flightradar24/10.0.0 (com.flightradar24.iphone; build:10.0.0.1; iOS 17.4.1) Alamofire/5.9.1",
+    })
+    # Ensure the JSON headers are refreshed with the new user-agent
+    Core.json_headers = {
+        "Accept": "application/json",
+        **Core.headers
     }
     Core.json_headers = {
         "accept": "application/json",

--- a/custom_components/flightradar24/__init__.py
+++ b/custom_components/flightradar24/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_ENABLE_TRACKER_DEFAULT,
     MIN_ALTITUDE,
     MAX_ALTITUDE,
+    CONF_PROXY_URL,
 )
 from FlightRadar24 import FlightRadar24API, Entity
 from FlightRadar24.core import Core
@@ -40,22 +41,29 @@ _LOGGER = getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
+    proxy_url = entry.data.get(CONF_PROXY_URL)
 
+    # iOS Spoofing Headers
     Core.headers = {
-        "Accept": "application/json",
-        "Accept-Encoding": "gzip, br",
-        "Accept-Language": "en-US,en;q=0.9",
-        "Cache-Control": "max-age=0",
-        "Referer": "https://www.flightradar24.com/",
-        "User-Agent": (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/120.0.0.0 Safari/537.36"
-        ),
+        "accept-encoding": "gzip, br",
+        "accept-language": "en-US,en;q=0.9",
+        "cache-control": "max-age=0",
+        "user-agent": "Flightradar24/10.0.0 (com.flightradar24.iphone; build:10.0.0.1; iOS 17.4.1) Alamofire/5.9.1",
     }
-    Core.json_headers = Core.headers.copy()
+    Core.json_headers = {
+        "accept": "application/json",
+        **Core.headers
+    }
 
-    client = FlightRadar24API()
+    # Initialize Client with or without Proxy
+    if proxy_url and proxy_url.strip() != "":
+        formatted_url = proxy_url.strip()
+        if not formatted_url.endswith("?url="):
+            formatted_url = f"{formatted_url.rstrip('/')}/?url="
+        client = FlightRadar24API(proxy_url=formatted_url)
+    else:
+        client = FlightRadar24API()
+
     if username and password:
         await hass.async_add_executor_job(client.login, username, password)
 

--- a/custom_components/flightradar24/__init__.py
+++ b/custom_components/flightradar24/__init__.py
@@ -38,27 +38,17 @@ PLATFORMS: list[Platform] = [
 _LOGGER = getLogger(__name__)
 
 
-Python
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
     proxy_url = entry.data.get(CONF_PROXY_URL)
 
-    # UPDATED: We only change the User-Agent, keeping all other original headers
+    # UPDATED: Use .update() to preserve the developer's original headers (like Accept: application/json)
     Core.headers.update({
         "user-agent": "Flightradar24/10.0.0 (com.flightradar24.iphone; build:10.0.0.1; iOS 17.4.1) Alamofire/5.9.1",
     })
-    # Ensure the JSON headers are refreshed with the new user-agent
-    Core.json_headers = {
-        "Accept": "application/json",
-        **Core.headers
-    }
-    Core.json_headers = {
-        "accept": "application/json",
-        **Core.headers
-    }
 
-    # Initialize Client with or without Proxy
+    # UPDATED: Initialize the client using the proxy regardless of login status
     if proxy_url and proxy_url.strip() != "":
         formatted_url = proxy_url.strip()
         if not formatted_url.endswith("?url="):

--- a/custom_components/flightradar24/config_flow.py
+++ b/custom_components/flightradar24/config_flow.py
@@ -77,15 +77,17 @@ class FlightRadarOptionsFlow(OptionsFlowWithConfigEntry):
             proxy_url = data.get(CONF_PROXY_URL, "")
 
             try:
+                # UPDATED: Proxy client is generated independently of the login credentials
+                if proxy_url and proxy_url.strip() != "":
+                    formatted_url = proxy_url.strip()
+                    if not formatted_url.endswith("?url="):
+                        formatted_url = f"{formatted_url.rstrip('/')}/?url="
+                    client = FlightRadar24API(proxy_url=formatted_url)
+                else:
+                    client = FlightRadar24API()
+
+                # ONLY check login if credentials are provided
                 if username and password:
-                    if proxy_url and proxy_url.strip() != "":
-                        formatted_url = proxy_url.strip()
-                        if not formatted_url.endswith("?url="):
-                            formatted_url = f"{formatted_url.rstrip('/')}/?url="
-                        client = FlightRadar24API(proxy_url=formatted_url)
-                    else:
-                        client = FlightRadar24API()
-                        
                     await self.hass.async_add_executor_job(client.login, username, password)
                 elif password and not username or username and not password:
                     errors['base'] = 'You need to pass username and password'

--- a/custom_components/flightradar24/config_flow.py
+++ b/custom_components/flightradar24/config_flow.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_ENABLE_TRACKER_DEFAULT,
     MIN_ALTITUDE,
     MAX_ALTITUDE,
+    CONF_PROXY_URL,
 )
 from FlightRadar24 import FlightRadar24API
 import homeassistant.helpers.config_validation as cv
@@ -48,6 +49,7 @@ class FlightRadarConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_LATITUDE): cv.latitude,
                     vol.Required(CONF_LONGITUDE): cv.longitude,
                     vol.Required(CONF_SCAN_INTERVAL, default=10): int,
+                    vol.Optional(CONF_PROXY_URL, default=""): cv.string,
                 }
             ),
             {
@@ -72,10 +74,18 @@ class FlightRadarOptionsFlow(OptionsFlowWithConfigEntry):
         if user_input is not None:
             username = data.get(CONF_USERNAME)
             password = data.get(CONF_PASSWORD)
+            proxy_url = data.get(CONF_PROXY_URL, "")
 
             try:
                 if username and password:
-                    client = FlightRadar24API()
+                    if proxy_url and proxy_url.strip() != "":
+                        formatted_url = proxy_url.strip()
+                        if not formatted_url.endswith("?url="):
+                            formatted_url = f"{formatted_url.rstrip('/')}/?url="
+                        client = FlightRadar24API(proxy_url=formatted_url)
+                    else:
+                        client = FlightRadar24API()
+                        
                     await self.hass.async_add_executor_job(client.login, username, password)
                 elif password and not username or username and not password:
                     errors['base'] = 'You need to pass username and password'
@@ -105,6 +115,7 @@ class FlightRadarOptionsFlow(OptionsFlowWithConfigEntry):
                                                          CONF_ENABLE_TRACKER_DEFAULT)}): cv.boolean,
             vol.Optional(CONF_USERNAME, description={"suggested_value": data.get(CONF_USERNAME, '')}): cv.string,
             vol.Optional(CONF_PASSWORD, description={"suggested_value": data.get(CONF_PASSWORD, '')}): cv.string,
+            vol.Optional(CONF_PROXY_URL, description={"suggested_value": data.get(CONF_PROXY_URL, '')}): cv.string,
         })
 
         return self.async_show_form(step_id="init", data_schema=data_schema, errors=errors)

--- a/custom_components/flightradar24/const.py
+++ b/custom_components/flightradar24/const.py
@@ -8,6 +8,7 @@ CONF_MOST_TRACKED = "most_tracked"
 CONF_ENABLE_TRACKER = "enable_tracker"
 CONF_MOST_TRACKED_DEFAULT = True
 CONF_ENABLE_TRACKER_DEFAULT = False
+CONF_PROXY_URL = "proxy_url"
 
 EVENT_ENTRY = f"{DOMAIN}_entry"
 EVENT_EXIT = f"{DOMAIN}_exit"

--- a/custom_components/flightradar24/manifest.json
+++ b/custom_components/flightradar24/manifest.json
@@ -1,11 +1,16 @@
 {
-    "domain": "flightradar24",
-    "name": "Flightradar24",
-    "codeowners": ["@AlexandrErohin"],
-    "config_flow": true,
-    "documentation": "https://github.com/AlexandrErohin/home-assistant-flightradar24",
-    "iot_class": "cloud_polling",
-    "issue_tracker": "https://github.com/AlexandrErohin/home-assistant-flightradar24/issues",
-    "requirements": ["FlightRadarAPI==1.4.0", "pycountry==24.6.1"],
-    "version": "1.32.3"
+  "domain": "flightradar24",
+  "name": "Flightradar24",
+  "codeowners": [
+    "@AlexandrErohin"
+  ],
+  "config_flow": true,
+  "documentation": "https://github.com/AlexandrErohin/home-assistant-flightradar24",
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/AlexandrErohin/home-assistant-flightradar24/issues",
+  "requirements": [
+    "ddima16-flightradarapi==1.4.1",
+    "pycountry==24.6.1"
+  ],
+  "version": "v1.32.1-proxyfix"
 }

--- a/custom_components/flightradar24/strings.json
+++ b/custom_components/flightradar24/strings.json
@@ -6,7 +6,8 @@
           "radius": "[%key:common::config_flow::data::radius%]",
           "latitude": "[%key:common::config_flow::data::latitude%]",
           "longitude": "[%key:common::config_flow::data::longitude%]",
-          "scan_interval": "[%key:common::config_flow::data::scan_interval%]"
+          "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
+          "proxy_url": "Cloudflare Proxy URL (Optional)"
         }
       }
     }
@@ -23,7 +24,8 @@
           "max_altitude": "[%key:common::config_flow::data::max_altitude%]",
           "most_tracked": "[%key:common::config_flow::data::most_tracked%]",
           "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "proxy_url": "Cloudflare Proxy URL (Optional)"
         }
       }
     }

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "filename": "flightradar24.zip",
   "homeassistant": "2023.9.3",
   "render_readme": true,
-  "zip_release": true
+  "zip_release": false
 }

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "filename": "flightradar24.zip",
   "homeassistant": "2023.9.3",
   "render_readme": true,
-  "zip_release": false
+  "zip_release": true
 }


### PR DESCRIPTION
The Problem:
Recently, Flightradar24 updated their Cloudflare Bot Management protection. This has resulted in widespread 403 Forbidden errors for users on the latest version of this integration, specifically when hitting the feed.js and search endpoints. Simply rotating generic browser User-Agents is no longer a viable long-term fix, as they are quickly flagged by Cloudflare's TLS fingerprinting and browser checks.

The Solution:
This PR introduces a two-layered approach to completely bypass the new Cloudflare restrictions without breaking existing functionality:

Global iOS Header Spoofing: Updated the Core.headers in __init__.py to mimic the official Flightradar24 iOS app. Cloudflare applies significantly more lenient rules to traffic originating from the official mobile app.

Optional Cloudflare Worker Proxy: For users subjected to strict IP bans or advanced TLS fingerprinting, this PR adds a completely optional proxy_url configuration field to the UI.

To support this, the API requirement in manifest.json has been bumped to the community-maintained ddima16-flightradarapi fork, which natively supports proxy routing.

Zero-Breaking Changes: If a user leaves the Proxy URL box blank, the integration falls back to a standard, direct connection.

Changes Proposed:

manifest.json: Updated requirements to use ddima16-flightradarapi==1.4.1.

__init__.py: Injected iOS User-Agent and JSON headers into Core.headers. Added proxy handling during client initialization.

config_flow.py: Added an optional proxy_url field to both the initial setup and the Options flow.

const.py & strings.json: Added the required constants and UI localization for the new Proxy URL field.

How to Test:

Install this branch.

Navigate to Settings > Devices & Services > Flightradar24 > Configure.

Verify the new Cloudflare Proxy URL (Optional) field appears.

Input a valid Cloudflare Worker Proxy URL (e.g., https://your-worker.workers.dev/?url=) and verify flights load successfully without 403 errors in the logs.

Clear the proxy box, reload the integration, and verify it successfully falls back to a direct connection.

Thank you for your ongoing work on this integration! Let me know if you need any adjustments to get this merged.

Please see this issue, i wrote a tutorial how to get the worker, and its free and easy
https://github.com/JeanExtreme002/FlightRadarAPI/issues/98#issuecomment-4392453324