### PR TITLE
Fix closest distance tracking

### DIFF
--- a/custom_components/flightradar24/api/flight.py
+++ b/custom_components/flightradar24/api/flight.py
@@ -228,7 +228,11 @@ class FlightProcessor:
                              tracked: dict[str, dict[str, Any]],
                              sensor_type: FlightType | None = None,
                              ) -> None:
-        last_position = tracked[obj.id].get('on_ground') if tracked is not None and obj.id in tracked else None
+        previous_flight = tracked.get(obj.id) if tracked is not None else None
+        last_position = previous_flight.get('on_ground') if previous_flight is not None else None
+        previous_closest_distance = (
+            previous_flight.get('closest_distance') if previous_flight is not None else None
+        )
         if (tracked is not None and obj.id in tracked and self._is_valid(tracked[obj.id])
                 and to_int(last_position) == obj.on_ground):
             flight = tracked[obj.id]
@@ -246,7 +250,10 @@ class FlightProcessor:
             flight['vertical_speed'] = obj.vertical_speed
             new_distance = obj.get_distance_from(self._point)
             flight['distance'] = new_distance
-            flight['closest_distance'] = min(new_distance, flight.get('closest_distance', new_distance))
+            flight['closest_distance'] = min(
+                new_distance,
+                previous_closest_distance if previous_closest_distance is not None else new_distance,
+            )
             flight['on_ground'] = obj.on_ground
             self._takeoff_and_landing(flight, last_position, obj.on_ground, sensor_type)
 


### PR DESCRIPTION
  ## Summary
Fix closest distance tracking so updates compare against the previous stored closest distance instead of the mutable flight dict value.

I had hit this when trying to use closest for my dashboard. (I am polling every 5s fwiw).


  ## Changes
  - Reuse the previous tracked flight entry when updating an existing flight
  - Preserve `closest_distance` from prior state when calculating the new minimum distance
  - Avoid repeated direct lookups into the tracked flight dictionary

  ## Testing on master
```
  15:51:40 distance_km=3.225572555181213 closest_distance_km=3.225572555181213
  15:51:45 distance_km=3.2493369541292894 closest_distance_km=3.2493369541292894
  15:51:50 distance_km=3.2930367500010704 closest_distance_km=3.2930367500010704
  15:51:55 distance_km=3.3671317666722556 closest_distance_km=3.3671317666722556
```
  ## Testing on my branch
```
  15:31:10 key=3fba15d1 distance_km=1.2179691502832108 closest_distance_km=1.2179691502832108
  15:31:15 key=3fba15d1 distance_km=1.3411662080938986 closest_distance_km=1.2179691502832108
  15:31:20 key=3fba15d1 distance_km=1.3945176078361383 closest_distance_km=1.2179691502832108
  15:31:30 key=3fba15d1 distance_km=1.8849296256019081 closest_distance_km=1.2179691502832108
  15:31:40 key=3fba15d1 distance_km=2.469931777591914 closest_distance_km=1.2179691502832108
  15:31:50 key=3fba15d1 distance_km=3.1187040191835873 closest_distance_km=1.2179691502832108
  15:31:55 key=3fba15d1 distance_km=3.364136398759484 closest_distance_km=1.2179691502832108
```