### PR TITLE
Adjust logging level for FlightRadarAPI #226 GZIP logs

### DIFF
--- a/custom_components/flightradar24/__init__.py
+++ b/custom_components/flightradar24/__init__.py
@@ -37,6 +37,9 @@ _LOGGER = getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    import logging
+    logging.getLogger("FlightRadarAPI").setLevel(logging.ERROR)
+    
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
 

--- a/custom_components/flightradar24/__init__.py
+++ b/custom_components/flightradar24/__init__.py
@@ -39,7 +39,6 @@ _LOGGER = getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     import logging
     logging.getLogger("FlightRadarAPI").setLevel(logging.ERROR)
-    
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
 


### PR DESCRIPTION
Set logging level for FlightRadarAPI to ERROR.

Its an harmless log warning, but lets get rid of it.
https://github.com/AlexandrErohin/home-assistant-flightradar24/issues/226