### PR TITLE
Fix: Flush data on scan toggle and prevent duplicate entities via registry migration #227

### DIFF
--- a/custom_components/flightradar24/switch.py
+++ b/custom_components/flightradar24/switch.py
@@ -36,7 +36,7 @@ class FlightRadar24ScanEntity(
             icon="mdi:connection",
             entity_category=EntityCategory.CONFIG,
         )
-        
+
         # FIXED: Lock down the unique ID using the entry_id
         self._attr_unique_id = f"{entry_id}_{DOMAIN}_{self.entity_description.key}"
 
@@ -53,7 +53,7 @@ class FlightRadar24ScanEntity(
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         self.coordinator.scanning = False
-        
+
         # --- THE PHANTOM PLANE FIX ---
         # 1. Manually empty the data lists in the flight processor
         if hasattr(self.coordinator, 'flight') and self.coordinator.flight is not None:
@@ -61,9 +61,9 @@ class FlightRadar24ScanEntity(
             self.coordinator.flight._entered = []
             self.coordinator.flight._exited = []
             self.coordinator.flight.clear_tracked()
-            
+
         # 2. Force the coordinator to broadcast this empty data to all sensors immediately
         self.coordinator.async_set_updated_data(None)
         # -----------------------------
-        
+
         self.async_write_ha_state()

--- a/custom_components/flightradar24/switch.py
+++ b/custom_components/flightradar24/switch.py
@@ -16,25 +16,29 @@ async def async_setup_entry(
         async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([FlightRadar24ScanEntity(coordinator)], False)
+    # Pass the static entry_id into the switch to prevent duplicates!
+    async_add_entities([FlightRadar24ScanEntity(coordinator, entry.entry_id)], False)
 
 
 class FlightRadar24ScanEntity(
     CoordinatorEntity[FlightRadar24Coordinator], SwitchEntity
 ):
+    _attr_has_entity_name = True
     entity_description: SwitchEntityDescription
 
-    def __init__(self, coordinator: FlightRadar24Coordinator) -> None:
+    def __init__(self, coordinator: FlightRadar24Coordinator, entry_id: str) -> None:
         super().__init__(coordinator)
 
         self._attr_device_info = coordinator.device_info
         self.entity_description = SwitchEntityDescription(
             key="scanning",
-            name="API data fetching",
+            translation_key="scanning",
             icon="mdi:connection",
             entity_category=EntityCategory.CONFIG,
         )
-        self._attr_unique_id = f"{coordinator.unique_id}_{DOMAIN}_{self.entity_description.key}"
+        
+        # FIXED: Lock down the unique ID using the entry_id
+        self._attr_unique_id = f"{entry_id}_{DOMAIN}_{self.entity_description.key}"
 
     @property
     def is_on(self) -> bool:
@@ -49,4 +53,17 @@ class FlightRadar24ScanEntity(
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         self.coordinator.scanning = False
+        
+        # --- THE PHANTOM PLANE FIX ---
+        # 1. Manually empty the data lists in the flight processor
+        if hasattr(self.coordinator, 'flight') and self.coordinator.flight is not None:
+            self.coordinator.flight._in_area = {}
+            self.coordinator.flight._entered = []
+            self.coordinator.flight._exited = []
+            self.coordinator.flight.clear_tracked()
+            
+        # 2. Force the coordinator to broadcast this empty data to all sensors immediately
+        self.coordinator.async_set_updated_data(None)
+        # -----------------------------
+        
         self.async_write_ha_state()


### PR DESCRIPTION
This PR bundles two major stability fixes for the integration regarding state handling and multi-instance setups.

1. The "Phantom Plane" Bug (Switch Fix):
#227
Issue: When a user toggled the "Scanning" switch to off, the integration successfully stopped API polling, but left the last known flight data sitting in Home Assistant's state machine. This caused frontend map cards to endlessly interpolate/loop the planes on the screen using stale heading and speed data.

#227
Fix: Updated async_turn_off in switch.py. When the switch is turned off, the integration now explicitly flushes the internal data lists (_in_area, _entered, etc.) and immediately forces a data update to broadcast the empty state. This instantly clears the map.

Also did find this:
2. Duplicate Entities for Multi-Instance Users (Sensor Fix):

Issue: Users running multiple instances of this integration at the exact same location are seeing duplicate "ghost" entities spawn on restart (e.g., _2, _3). This is because coordinator.unique_id relies on geo-coordinates. Multiple instances at the same location generate clashing IDs.

Fix: Locked down the unique_id for all sensors and switches to use Home Assistant's immutable entry.entry_id.

Zero Breaking Changes: 

To ensure existing users do not lose their history graphs or break their dashboards, I implemented an Entity Registry migration in async_setup_entry. On startup, it checks if a sensor exists under the old coordinate-based ID and seamlessly updates it to the new entry_id format behind the scenes.