### PR TITLE
Fix import statement for TrackerEntity

### DIFF
--- a/custom_components/flightradar24/device_tracker.py
+++ b/custom_components/flightradar24/device_tracker.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback


### PR DESCRIPTION
Fix the deprecated tracker entity warning from HASS 2027.6
<img width="876" height="39" alt="{790B15C0-BBF3-4112-AFE7-9F6EFA72FB71}" src="https://github.com/user-attachments/assets/092c90d2-2d62-48db-90e9-e197fe0e5369" />
