### PR TITLE
Individual Device Tracker and Sensor for Additional Tracked Flights

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ before copying YAML examples.
 ### <a id="device-tracker">Device Tracker</a>
 You may be interested to add a live flight as device_tracker with the flight information to a person in HA.
 To use it - you need to activate this feature in [Edit Configuration](#edit-configuration).
-When it is enabled, this integration creates a separate `device_tracker` for each live flight in the additional tracked list.
-Each tracker uses the configured map tracker naming style and updates independently while that flight remains live.
+When it is enabled, this integration creates a separate `device_tracker` for each flight in the additional tracked list.
+Each tracker uses the configured map tracker naming style and updates independently while that flight remains additional tracked.
 
 ### Tracked Flight Card Sensors
 For each flight in the Additional tracked list, the integration also creates a separate sensor named like `sensor.flightradar24_tracked_flight_<flight>`.

--- a/README.md
+++ b/README.md
@@ -267,9 +267,8 @@ before copying YAML examples.
 ### <a id="device-tracker">Device Tracker</a>
 You may be interested to add a live flight as device_tracker with the flight information to a person in HA.
 To use it - you need to activate this feature in [Edit Configuration](#edit-configuration).
-When it is enabled - this integration creates device_tracker with static name `device_tracker.flightradar24` and
-this device_tracker updates when there is a live flight in the additional tracked list.
-It works ONLY with one live flight from the additional tracked list at a time!
+When it is enabled, this integration creates a separate `device_tracker` for each live flight in the additional tracked list.
+Each tracker uses the configured map tracker naming style and updates independently while that flight remains live.
 
 ### Configuration
  - Add to track - Pass flight number or call sign or aircraft registration number to track flight outside your area. It adds flight to Additional tracked sensor

--- a/README.md
+++ b/README.md
@@ -270,6 +270,17 @@ To use it - you need to activate this feature in [Edit Configuration](#edit-conf
 When it is enabled, this integration creates a separate `device_tracker` for each live flight in the additional tracked list.
 Each tracker uses the configured map tracker naming style and updates independently while that flight remains live.
 
+### Tracked Flight Card Sensors
+For each flight in the Additional tracked list, the integration also creates a separate sensor named like `sensor.flightradar24_tracked_flight_<flight>`.
+Each of these sensors exposes a single flight in its `flights` attribute, so it can be used directly with cards that expect a Flightradar24 sensor, such as [flightradar-flight-card](https://github.com/plckr/flightradar-flight-card).
+
+```yaml
+type: custom:flightradar-flight-card
+entities:
+  - entity_id: sensor.flightradar24_tracked_flight_ba123
+    title: BA123
+```
+
 ### Configuration
  - Add to track - Pass flight number or call sign or aircraft registration number to track flight outside your area. It adds flight to Additional tracked sensor
  - Remove from track - Pass flight number or call sign or aircraft registration number to remove a flight from Additional tracked sensor

--- a/custom_components/flightradar24/api/flight.py
+++ b/custom_components/flightradar24/api/flight.py
@@ -15,6 +15,7 @@ from ..const import (
     EVENT_TRACKED_ARRIVED_GATE,
     EVENT_TRACKED_LEFT_GATE,
 )
+from ..flight_key import TRACKING_KEY, ensure_tracking_key
 import pycountry
 
 
@@ -135,12 +136,15 @@ class FlightProcessor:
             'aircraft_registration': value.get('aircraft_registration'),
             'flight_number': value.get('flight_number'),
             'callsign': value.get('callsign'),
+            TRACKING_KEY: value.get(TRACKING_KEY),
         } for key, value in self._tracked.items()}
 
     def clear_tracked(self) -> None:
         self._tracked = {}
 
     def set_tracked(self, tracked: dict[str, dict[str, Any]]) -> None:
+        for flight in tracked.values():
+            ensure_tracking_key(flight)
         self._tracked = tracked
 
     def enable_most_tracked(self) -> None:
@@ -152,6 +156,8 @@ class FlightProcessor:
         self._find_flight(found, number)
         if not found:
             return None
+        for flight in found.values():
+            ensure_tracking_key(flight, number, prefer_fallback=True)
         self._tracked = self._tracked | found if self._tracked else found
 
         return found
@@ -199,6 +205,7 @@ class FlightProcessor:
             flights = self._client.get_flights(registration=','.join(reg_numbers))
             for obj in flights:
                 self._update_flights_data(obj, current, self._tracked, FlightType.TRACKED)
+                self._set_current_tracking_key(current[obj.id], obj.id)
                 current[obj.id]['tracked_type'] = 'live'
                 if current[obj.id].get('flight_number'):
                     current_flights.append(current[obj.id].get('flight_number'))
@@ -217,12 +224,17 @@ class FlightProcessor:
                 number = flight_number or callsign
                 if not number:
                     continue
-                size = current.__len__()
+                current_keys = set(current)
                 self._find_flight(current, number)
-                if size != current.__len__():
+                new_keys = set(current) - current_keys
+                if new_keys:
+                    tracking_key = ensure_tracking_key(self._tracked[flight_id], flight_id)
+                    for new_key in new_keys:
+                        current[new_key][TRACKING_KEY] = tracking_key
                     current_flights.append(number)
                 else:
                     current[flight_id] = self._tracked[flight_id]
+                    ensure_tracking_key(current[flight_id], flight_id)
                     current[flight_id]['tracked_type'] = 'not_found'
 
         # --- AUTO-CLEANUP LOGIC WRAPPED IN CONFIG CHECK ---
@@ -259,6 +271,14 @@ class FlightProcessor:
         # -----------------------
 
         self._tracked = current
+
+    def _set_current_tracking_key(self, flight: dict[str, Any], flight_id: str) -> None:
+        for old_key, old_flight in self._tracked.items():
+            for field in ('id', 'aircraft_registration', 'flight_number', 'callsign'):
+                if flight.get(field) and flight.get(field) == old_flight.get(field):
+                    flight[TRACKING_KEY] = ensure_tracking_key(old_flight, old_key)
+                    return
+        ensure_tracking_key(flight, flight_id)
 
     def _find_flight(self, current: dict[str, dict[str, Any]], number: str) -> None:
         def process_search_flight(objects: dict, search: str) -> dict | None:

--- a/custom_components/flightradar24/button.py
+++ b/custom_components/flightradar24/button.py
@@ -32,6 +32,7 @@ class FlightRadar24ButtonEntityDescription(
 async def clear_tracked_button(coordinator: FlightRadar24Coordinator) -> None:
     """Async wrapper to clear tracked flights (sync method)."""
     coordinator.flight.clear_tracked()
+    coordinator.async_set_updated_data(coordinator.data)
 
 
 BUTTON_TYPES = (

--- a/custom_components/flightradar24/coordinator.py
+++ b/custom_components/flightradar24/coordinator.py
@@ -59,6 +59,8 @@ class FlightRadar24Coordinator(DataUpdateCoordinator[int]):
             found = await self.hass.async_add_executor_job(self.flight.add_track, number)
             if not found:
                 self.logger.error('FlightRadar24: Add Track - No flight found by - {}'.format(number))
+            else:
+                self.async_set_updated_data(self.data)
         except Exception as e:
             self.logger.error("FlightRadar24: %s", e)
 
@@ -70,6 +72,8 @@ class FlightRadar24Coordinator(DataUpdateCoordinator[int]):
         remove = await self.hass.async_add_executor_job(self.flight.remove_track, number)
         if not remove:
             self.logger.error('FlightRadar24: Remove Track - No flight found by - {}'.format(number))
+        else:
+            self.async_set_updated_data(self.data)
 
     async def update_airport_track(self, code: str) -> None:
         if not self.scanning:

--- a/custom_components/flightradar24/device_tracker.py
+++ b/custom_components/flightradar24/device_tracker.py
@@ -6,6 +6,7 @@ from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import FlightRadar24Coordinator
 from .flight_key import flight_tracker_key
@@ -32,6 +33,12 @@ async def async_setup_entry(
         async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    ent_reg = er.async_get(hass)
+    old_unique_id = f"{coordinator.unique_id}_{DOMAIN}"
+    if entity_id := ent_reg.async_get_entity_id("device_tracker", DOMAIN, old_unique_id):
+        ent_reg.async_remove(entity_id)
+
     if not coordinator.enable_tracker:
         return
 
@@ -40,6 +47,21 @@ async def async_setup_entry(
     @callback
     def add_new_trackers() -> None:
         """Add a device tracker for each live tracked flight."""
+        current_keys = {
+            tracker_key
+            for flight in coordinator.flight.tracked_list
+            if (tracker_key := flight_tracker_key(flight))
+        }
+        for tracker_key in set(tracked) - current_keys:
+            tracker = tracked.pop(tracker_key)
+            if entity_id := ent_reg.async_get_entity_id(
+                    "device_tracker",
+                    DOMAIN,
+                    FlightRadar24Tracker.unique_id(entry.entry_id, tracker_key),
+            ):
+                ent_reg.async_remove(entity_id)
+            hass.async_create_task(tracker.async_remove())
+
         if not coordinator.enable_tracker:
             return
 
@@ -64,19 +86,34 @@ class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
     def __init__(self, coordinator: FlightRadar24Coordinator, entry_id: str, tracker_key: str) -> None:
         self.tracker_key = tracker_key
         super().__init__(coordinator)
+        self._info = self._find_info()
         self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = f"{entry_id}_{DOMAIN}_{tracker_key}"
+        self._attr_unique_id = self.unique_id(entry_id, tracker_key)
 
-    @property
-    def info(self) -> dict[str, Any]:
+    @staticmethod
+    def unique_id(entry_id: str, tracker_key: str) -> str:
+        return f"{entry_id}_{DOMAIN}_{tracker_key}"
+
+    def _find_info(self) -> dict[str, Any]:
         for flight in _live_tracked_flights(self.coordinator):
             if flight_tracker_key(flight) == self.tracker_key:
                 return flight
         return {}
 
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._info = self._find_info()
+        self.async_write_ha_state()
+
+    @property
+    def info(self) -> dict[str, Any]:
+        return self._info
+
     @property
     def available(self) -> bool:
-        return bool(self.info)
+        info = self.info
+        return bool(info)
 
     @property
     def source_type(self) -> SourceType:
@@ -84,15 +121,18 @@ class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        return self.info
+        info = self.info
+        return info
 
     @property
     def latitude(self) -> float | None:
-        return self.info.get('latitude')
+        info = self.info
+        return info.get('latitude')
 
     @property
     def longitude(self) -> float | None:
-        return self.info.get('longitude')
+        info = self.info
+        return info.get('longitude')
 
     @property
     def icon(self) -> str:
@@ -101,12 +141,14 @@ class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
     @property
     def entity_picture(self) -> str | None:
         # This tells the map to show the actual photo of the plane!
-        return self.info.get('aircraft_photo_small')
+        info = self.info
+        return info.get('aircraft_photo_small')
 
     @property
     def name(self) -> str:
+        info = self.info
         # If no flight is currently tracked, return the default domain name
-        if not self.info:
+        if not info:
             return DOMAIN
 
         # Check what the user selected in the Integration Options
@@ -115,10 +157,10 @@ class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
         )
 
         # Safely grab the flight data, falling back to 'N/A' if it's missing
-        callsign = self.info.get('callsign') or self.info.get('flight_number') or "Unknown"
-        reg = self.info.get('aircraft_registration') or callsign
-        origin = self.info.get('airport_origin_code_iata') or "N/A"
-        dest = self.info.get('airport_destination_code_iata') or "N/A"
+        callsign = info.get('callsign') or info.get('flight_number') or "Unknown"
+        reg = info.get('aircraft_registration') or callsign
+        origin = info.get('airport_origin_code_iata') or "N/A"
+        dest = info.get('airport_destination_code_iata') or "N/A"
 
         # Piece the string together based on their preference!
         if style == TRACKER_NAME_CALLSIGN_ROUTE:

--- a/custom_components/flightradar24/device_tracker.py
+++ b/custom_components/flightradar24/device_tracker.py
@@ -27,6 +27,18 @@ def _live_tracked_flights(coordinator: FlightRadar24Coordinator) -> list[dict[st
     ]
 
 
+@callback
+def _remove_bad_registry_entries(ent_reg: er.EntityRegistry) -> None:
+    """Remove entities created with a non-serializable unique ID."""
+    for entity_entry in list(ent_reg.entities.values()):
+        if (
+                entity_entry.domain == "device_tracker"
+                and entity_entry.platform == DOMAIN
+                and not isinstance(entity_entry.unique_id, str)
+        ):
+            ent_reg.async_remove(entity_entry.entity_id)
+
+
 async def async_setup_entry(
         hass: HomeAssistant,
         entry: ConfigEntry,
@@ -35,6 +47,7 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
     ent_reg = er.async_get(hass)
+    _remove_bad_registry_entries(ent_reg)
     old_unique_id = f"{coordinator.unique_id}_{DOMAIN}"
     if entity_id := ent_reg.async_get_entity_id("device_tracker", DOMAIN, old_unique_id):
         ent_reg.async_remove(entity_id)
@@ -57,10 +70,11 @@ async def async_setup_entry(
             if entity_id := ent_reg.async_get_entity_id(
                     "device_tracker",
                     DOMAIN,
-                    FlightRadar24Tracker.unique_id(entry.entry_id, tracker_key),
+                    FlightRadar24Tracker.make_unique_id(entry.entry_id, tracker_key),
             ):
                 ent_reg.async_remove(entity_id)
-            hass.async_create_task(tracker.async_remove())
+            if tracker.hass is not None:
+                hass.async_create_task(tracker.async_remove())
 
         if not coordinator.enable_tracker:
             return
@@ -88,10 +102,10 @@ class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
         super().__init__(coordinator)
         self._info = self._find_info()
         self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = self.unique_id(entry_id, tracker_key)
+        self._attr_unique_id = self.make_unique_id(entry_id, tracker_key)
 
     @staticmethod
-    def unique_id(entry_id: str, tracker_key: str) -> str:
+    def make_unique_id(entry_id: str, tracker_key: str) -> str:
         return f"{entry_id}_{DOMAIN}_{tracker_key}"
 
     def _find_info(self) -> dict[str, Any]:

--- a/custom_components/flightradar24/device_tracker.py
+++ b/custom_components/flightradar24/device_tracker.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import re
 from typing import Any
 
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
@@ -9,6 +8,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import FlightRadar24Coordinator
+from .flight_key import flight_tracker_key
 from .const import (
     DOMAIN,
     CONF_TRACKER_NAME_STYLE,
@@ -16,20 +16,6 @@ from .const import (
     TRACKER_NAME_CALLSIGN_ROUTE,
     TRACKER_NAME_REG_ROUTE,
 )
-
-
-def _normalize_tracker_key(value: Any) -> str:
-    """Normalize a flight identifier for use in stable tracker unique IDs."""
-    return re.sub(r"[^a-z0-9_]+", "_", str(value).strip().lower()).strip("_")
-
-
-def _flight_tracker_key(flight: dict[str, Any]) -> str | None:
-    """Return a stable tracker key for a recurring tracked flight."""
-    for field in ("flight_number", "callsign", "aircraft_registration", "id"):
-        if value := flight.get(field):
-            if normalized := _normalize_tracker_key(value):
-                return f"{field}_{normalized}"
-    return None
 
 
 def _live_tracked_flights(coordinator: FlightRadar24Coordinator) -> list[dict[str, Any]]:
@@ -59,7 +45,7 @@ async def async_setup_entry(
 
         new_entities: list[FlightRadar24Tracker] = []
         for flight in _live_tracked_flights(coordinator):
-            tracker_key = _flight_tracker_key(flight)
+            tracker_key = flight_tracker_key(flight)
             if not tracker_key or tracker_key in tracked:
                 continue
 
@@ -84,7 +70,7 @@ class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
     @property
     def info(self) -> dict[str, Any]:
         for flight in _live_tracked_flights(self.coordinator):
-            if _flight_tracker_key(flight) == self.tracker_key:
+            if flight_tracker_key(flight) == self.tracker_key:
                 return flight
         return {}
 

--- a/custom_components/flightradar24/device_tracker.py
+++ b/custom_components/flightradar24/device_tracker.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import FlightRadar24Coordinator
-from .flight_key import flight_tracker_key
+from .flight_key import flight_display_name, flight_tracker_key
 from .const import (
     DOMAIN,
     CONF_TRACKER_NAME_STYLE,
@@ -39,6 +39,26 @@ def _remove_bad_registry_entries(ent_reg: er.EntityRegistry) -> None:
             ent_reg.async_remove(entity_entry.entity_id)
 
 
+@callback
+def _remove_stale_tracker_entries(
+        ent_reg: er.EntityRegistry,
+        entry_id: str,
+        current_keys: set[str],
+) -> None:
+    """Remove tracked-flight device tracker registry entries no longer tracked."""
+    prefix = f"{entry_id}_{DOMAIN}_"
+    for entity_entry in list(ent_reg.entities.values()):
+        unique_id = entity_entry.unique_id
+        if (
+                entity_entry.domain == "device_tracker"
+                and entity_entry.platform == DOMAIN
+                and isinstance(unique_id, str)
+                and unique_id.startswith(prefix)
+                and unique_id.removeprefix(prefix) not in current_keys
+        ):
+            ent_reg.async_remove(entity_entry.entity_id)
+
+
 async def async_setup_entry(
         hass: HomeAssistant,
         entry: ConfigEntry,
@@ -59,12 +79,13 @@ async def async_setup_entry(
 
     @callback
     def add_new_trackers() -> None:
-        """Add a device tracker for each live tracked flight."""
+        """Add a device tracker for each additional tracked flight."""
         current_keys = {
             tracker_key
             for flight in coordinator.flight.tracked_list
             if (tracker_key := flight_tracker_key(flight))
         }
+        _remove_stale_tracker_entries(ent_reg, entry.entry_id, current_keys)
         for tracker_key in set(tracked) - current_keys:
             tracker = tracked.pop(tracker_key)
             if entity_id := ent_reg.async_get_entity_id(
@@ -80,7 +101,7 @@ async def async_setup_entry(
             return
 
         new_entities: list[FlightRadar24Tracker] = []
-        for flight in _live_tracked_flights(coordinator):
+        for flight in coordinator.flight.tracked_list:
             tracker_key = flight_tracker_key(flight)
             if not tracker_key or tracker_key in tracked:
                 continue
@@ -114,6 +135,12 @@ class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
                 return flight
         return {}
 
+    def _find_tracked_flight(self) -> dict[str, Any]:
+        for flight in self.coordinator.flight.tracked_list:
+            if flight_tracker_key(flight) == self.tracker_key:
+                return flight
+        return {}
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -127,7 +154,7 @@ class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
     @property
     def available(self) -> bool:
         info = self.info
-        return bool(info)
+        return bool(info and info.get('latitude') is not None and info.get('longitude') is not None)
 
     @property
     def source_type(self) -> SourceType:
@@ -136,16 +163,20 @@ class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         info = self.info
-        return info
+        return info or self._find_tracked_flight()
 
     @property
     def latitude(self) -> float | None:
         info = self.info
+        if not info or info.get('latitude') is None or info.get('longitude') is None:
+            return None
         return info.get('latitude')
 
     @property
     def longitude(self) -> float | None:
         info = self.info
+        if not info or info.get('latitude') is None or info.get('longitude') is None:
+            return None
         return info.get('longitude')
 
     @property
@@ -156,13 +187,16 @@ class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
     def entity_picture(self) -> str | None:
         # This tells the map to show the actual photo of the plane!
         info = self.info
+        if not info or info.get('latitude') is None or info.get('longitude') is None:
+            return None
         return info.get('aircraft_photo_small')
 
     @property
     def name(self) -> str:
         info = self.info
+        flight = info or self._find_tracked_flight()
         # If no flight is currently tracked, return the default domain name
-        if not info:
+        if not flight:
             return DOMAIN
 
         # Check what the user selected in the Integration Options
@@ -171,10 +205,10 @@ class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
         )
 
         # Safely grab the flight data, falling back to 'N/A' if it's missing
-        callsign = info.get('callsign') or info.get('flight_number') or "Unknown"
-        reg = info.get('aircraft_registration') or callsign
-        origin = info.get('airport_origin_code_iata') or "N/A"
-        dest = info.get('airport_destination_code_iata') or "N/A"
+        callsign = flight.get('callsign') or flight.get('flight_number') or "Unknown"
+        reg = flight.get('aircraft_registration') or callsign
+        origin = flight.get('airport_origin_code_iata') or "N/A"
+        dest = flight.get('airport_destination_code_iata') or "N/A"
 
         # Piece the string together based on their preference!
         if style == TRACKER_NAME_CALLSIGN_ROUTE:
@@ -183,4 +217,4 @@ class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
             return f"{reg} ({origin} - {dest})"
 
         # Default fallback (Callsign only)
-        return callsign
+        return callsign or flight_display_name(flight)

--- a/custom_components/flightradar24/device_tracker.py
+++ b/custom_components/flightradar24/device_tracker.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import re
 from typing import Any
 
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
@@ -17,12 +18,26 @@ from .const import (
 )
 
 
-def _live_tracked_flights(coordinator: FlightRadar24Coordinator) -> dict[str, dict[str, Any]]:
-    return {
-        flight_id: flight
-        for flight_id, flight in coordinator.flight.tracked.items()
+def _normalize_tracker_key(value: Any) -> str:
+    """Normalize a flight identifier for use in stable tracker unique IDs."""
+    return re.sub(r"[^a-z0-9_]+", "_", str(value).strip().lower()).strip("_")
+
+
+def _flight_tracker_key(flight: dict[str, Any]) -> str | None:
+    """Return a stable tracker key for a recurring tracked flight."""
+    for field in ("flight_number", "callsign", "aircraft_registration", "id"):
+        if value := flight.get(field):
+            if normalized := _normalize_tracker_key(value):
+                return f"{field}_{normalized}"
+    return None
+
+
+def _live_tracked_flights(coordinator: FlightRadar24Coordinator) -> list[dict[str, Any]]:
+    return [
+        flight
+        for flight in coordinator.flight.tracked.values()
         if flight.get('tracked_type') == 'live'
-    }
+    ]
 
 
 async def async_setup_entry(
@@ -43,12 +58,13 @@ async def async_setup_entry(
             return
 
         new_entities: list[FlightRadar24Tracker] = []
-        for flight_id in _live_tracked_flights(coordinator):
-            if flight_id in tracked:
+        for flight in _live_tracked_flights(coordinator):
+            tracker_key = _flight_tracker_key(flight)
+            if not tracker_key or tracker_key in tracked:
                 continue
 
-            tracker = FlightRadar24Tracker(coordinator, entry.entry_id, flight_id)
-            tracked[flight_id] = tracker
+            tracker = FlightRadar24Tracker(coordinator, entry.entry_id, tracker_key)
+            tracked[tracker_key] = tracker
             new_entities.append(tracker)
 
         if new_entities:
@@ -59,17 +75,17 @@ async def async_setup_entry(
 
 
 class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
-    def __init__(self, coordinator: FlightRadar24Coordinator, entry_id: str, flight_id: str) -> None:
-        self.flight_id = flight_id
+    def __init__(self, coordinator: FlightRadar24Coordinator, entry_id: str, tracker_key: str) -> None:
+        self.tracker_key = tracker_key
         super().__init__(coordinator)
         self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = f"{entry_id}_{DOMAIN}_{flight_id}"
+        self._attr_unique_id = f"{entry_id}_{DOMAIN}_{tracker_key}"
 
     @property
     def info(self) -> dict[str, Any]:
-        flight = self.coordinator.flight.tracked.get(self.flight_id)
-        if flight and flight.get('tracked_type') == 'live':
-            return flight
+        for flight in _live_tracked_flights(self.coordinator):
+            if _flight_tracker_key(flight) == self.tracker_key:
+                return flight
         return {}
 
     @property

--- a/custom_components/flightradar24/device_tracker.py
+++ b/custom_components/flightradar24/device_tracker.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+from typing import Any
+
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry
@@ -15,6 +17,14 @@ from .const import (
 )
 
 
+def _live_tracked_flights(coordinator: FlightRadar24Coordinator) -> dict[str, dict[str, Any]]:
+    return {
+        flight_id: flight
+        for flight_id, flight in coordinator.flight.tracked.items()
+        if flight.get('tracked_type') == 'live'
+    }
+
+
 async def async_setup_entry(
         hass: HomeAssistant,
         entry: ConfigEntry,
@@ -24,51 +34,54 @@ async def async_setup_entry(
     if not coordinator.enable_tracker:
         return
 
-    tracked = FlightRadar24Tracker(coordinator)
-    async_add_entities([tracked])
+    tracked: dict[str, FlightRadar24Tracker] = {}
 
     @callback
-    def coordinator_updated():
-        """Update the status of the device."""
-        update_items(coordinator, tracked)
+    def add_new_trackers() -> None:
+        """Add a device tracker for each live tracked flight."""
+        if not coordinator.enable_tracker:
+            return
 
-    entry.async_on_unload(coordinator.async_add_listener(coordinator_updated))
-    coordinator_updated()
+        new_entities: list[FlightRadar24Tracker] = []
+        for flight_id in _live_tracked_flights(coordinator):
+            if flight_id in tracked:
+                continue
 
+            tracker = FlightRadar24Tracker(coordinator, entry.entry_id, flight_id)
+            tracked[flight_id] = tracker
+            new_entities.append(tracker)
 
-@callback
-def update_items(coordinator: FlightRadar24Coordinator, tracked: FlightRadar24Tracker) -> None:
-    if not coordinator.enable_tracker:
-        return
+        if new_entities:
+            async_add_entities(new_entities)
 
-    if not tracked.info:
-        for flight in coordinator.flight.tracked.values():
-            if flight.get('tracked_type') == 'live':
-                tracked.info = flight
-                break
-    else:
-        flight = coordinator.flight.tracked.get(tracked.info['id'])
-        if flight and flight.get('tracked_type') == 'live':
-            tracked.info = coordinator.flight.tracked.get(tracked.info['id'])
-        else:
-            tracked.info = {}
+    entry.async_on_unload(coordinator.async_add_listener(add_new_trackers))
+    add_new_trackers()
 
 
 class FlightRadar24Tracker(CoordinatorEntity, TrackerEntity):
-    def __init__(self, coordinator: FlightRadar24Coordinator) -> None:
-        self.info = {}
+    def __init__(self, coordinator: FlightRadar24Coordinator, entry_id: str, flight_id: str) -> None:
+        self.flight_id = flight_id
         super().__init__(coordinator)
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{entry_id}_{DOMAIN}_{flight_id}"
+
+    @property
+    def info(self) -> dict[str, Any]:
+        flight = self.coordinator.flight.tracked.get(self.flight_id)
+        if flight and flight.get('tracked_type') == 'live':
+            return flight
+        return {}
+
+    @property
+    def available(self) -> bool:
+        return bool(self.info)
 
     @property
     def source_type(self) -> SourceType:
         return SourceType.GPS
 
     @property
-    def unique_id(self) -> str:
-        return f"{self.coordinator.unique_id}_{DOMAIN}"
-
-    @property
-    def extra_state_attributes(self) -> dict[str, str]:
+    def extra_state_attributes(self) -> dict[str, Any]:
         return self.info
 
     @property

--- a/custom_components/flightradar24/device_tracker.py
+++ b/custom_components/flightradar24/device_tracker.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from typing import Any
 
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/flightradar24/flight_key.py
+++ b/custom_components/flightradar24/flight_key.py
@@ -3,19 +3,49 @@ from __future__ import annotations
 import re
 from typing import Any
 
+TRACKING_KEY = "tracking_key"
+
 
 def normalize_flight_key(value: Any) -> str:
     """Normalize a flight identifier for stable Home Assistant unique IDs."""
     return re.sub(r"[^a-z0-9_]+", "_", str(value).strip().lower()).strip("_")
 
 
+def tracked_input_key(value: Any) -> str | None:
+    """Return a stable key based on the value the user asked to track."""
+    if normalized := normalize_flight_key(value):
+        return f"tracked_{normalized}"
+    return None
+
+
 def flight_tracker_key(flight: dict[str, Any]) -> str | None:
     """Return a stable key for a recurring tracked flight."""
+    if tracking_key := flight.get(TRACKING_KEY):
+        return tracking_key
+
     for field in ("flight_number", "callsign", "aircraft_registration", "id"):
         if value := flight.get(field):
             if normalized := normalize_flight_key(value):
                 return f"{field}_{normalized}"
     return None
+
+
+def ensure_tracking_key(
+        flight: dict[str, Any],
+        fallback: Any = None,
+        prefer_fallback: bool = False,
+) -> str | None:
+    """Set and return the stable key for a tracked flight."""
+    if tracking_key := flight.get(TRACKING_KEY):
+        return tracking_key
+
+    if prefer_fallback:
+        tracking_key = tracked_input_key(fallback) or flight_tracker_key(flight)
+    else:
+        tracking_key = flight_tracker_key(flight) or tracked_input_key(fallback)
+    if tracking_key:
+        flight[TRACKING_KEY] = tracking_key
+    return tracking_key
 
 
 def flight_display_name(flight: dict[str, Any]) -> str:

--- a/custom_components/flightradar24/flight_key.py
+++ b/custom_components/flightradar24/flight_key.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+def normalize_flight_key(value: Any) -> str:
+    """Normalize a flight identifier for stable Home Assistant unique IDs."""
+    return re.sub(r"[^a-z0-9_]+", "_", str(value).strip().lower()).strip("_")
+
+
+def flight_tracker_key(flight: dict[str, Any]) -> str | None:
+    """Return a stable key for a recurring tracked flight."""
+    for field in ("flight_number", "callsign", "aircraft_registration", "id"):
+        if value := flight.get(field):
+            if normalized := normalize_flight_key(value):
+                return f"{field}_{normalized}"
+    return None
+
+
+def flight_display_name(flight: dict[str, Any]) -> str:
+    """Return a readable name for a tracked flight sensor."""
+    return (
+        flight.get("flight_number")
+        or flight.get("callsign")
+        or flight.get("aircraft_registration")
+        or flight.get("id")
+        or "Tracked flight"
+    )

--- a/custom_components/flightradar24/sensor.py
+++ b/custom_components/flightradar24/sensor.py
@@ -195,6 +195,26 @@ def _remove_bad_registry_entries(ent_reg: er.EntityRegistry) -> None:
             ent_reg.async_remove(entity_entry.entity_id)
 
 
+@callback
+def _remove_stale_tracked_flight_entries(
+        ent_reg: er.EntityRegistry,
+        entry_id: str,
+        current_keys: set[str],
+) -> None:
+    """Remove tracked-flight sensor registry entries no longer tracked."""
+    prefix = f"{entry_id}_{DOMAIN}_tracked_flight_"
+    for entity_entry in list(ent_reg.entities.values()):
+        unique_id = entity_entry.unique_id
+        if (
+                entity_entry.domain == "sensor"
+                and entity_entry.platform == DOMAIN
+                and isinstance(unique_id, str)
+                and unique_id.startswith(prefix)
+                and unique_id.removeprefix(prefix) not in current_keys
+        ):
+            ent_reg.async_remove(entity_entry.entity_id)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
@@ -230,6 +250,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             for flight in coordinator.flight.tracked_list
             if (tracker_key := flight_tracker_key(flight))
         }
+        _remove_stale_tracked_flight_entries(ent_reg, entry.entry_id, current_keys)
         for tracker_key in set(tracked_sensors) - current_keys:
             sensor = tracked_sensors.pop(tracker_key)
             if entity_id := ent_reg.async_get_entity_id(

--- a/custom_components/flightradar24/sensor.py
+++ b/custom_components/flightradar24/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers import entity_registry as er  # Imported for migration
 from .coordinator import FlightRadar24Coordinator
+from .flight_key import flight_display_name, flight_tracker_key
 import datetime
 import copy
 
@@ -206,6 +207,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         sensors.append(FlightRadar24RestoreSensor(coordinator, description, entry.entry_id))
     async_add_entities(sensors, False)
 
+    tracked_sensors: dict[str, FlightRadar24TrackedFlightSensor] = {}
+
+    @callback
+    def add_tracked_flight_sensors() -> None:
+        """Add one sensor per additional tracked flight."""
+        new_entities: list[FlightRadar24TrackedFlightSensor] = []
+        for flight in coordinator.flight.tracked_list:
+            tracker_key = flight_tracker_key(flight)
+            if not tracker_key or tracker_key in tracked_sensors:
+                continue
+
+            sensor = FlightRadar24TrackedFlightSensor(coordinator, entry.entry_id, tracker_key)
+            tracked_sensors[tracker_key] = sensor
+            new_entities.append(sensor)
+
+        if new_entities:
+            async_add_entities(new_entities)
+
+    entry.async_on_unload(coordinator.async_add_listener(add_tracked_flight_sensors))
+    add_tracked_flight_sensors()
+
 
 class FlightRadar24Sensor(CoordinatorEntity[FlightRadar24Coordinator], SensorEntity):
     _attr_has_entity_name = True
@@ -257,3 +279,57 @@ class FlightRadar24RestoreSensor(FlightRadar24Sensor, RestoreSensor):
             for flight in last_state.attributes.get('flights', {}):
                 tracked[flight.get('id') or flight.get('flight_number') or flight.get('callsign')] = flight
             self.coordinator.flight.set_tracked(tracked)
+            self.coordinator.async_set_updated_data(self.coordinator.data)
+
+
+class FlightRadar24TrackedFlightSensor(CoordinatorEntity[FlightRadar24Coordinator], SensorEntity):
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:airplane"
+    _unrecorded_attributes = frozenset({"flights", "flight"})
+
+    def __init__(
+            self,
+            coordinator: FlightRadar24Coordinator,
+            entry_id: str,
+            tracker_key: str,
+    ) -> None:
+        self.tracker_key = tracker_key
+        super().__init__(coordinator)
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = f"{entry_id}_{DOMAIN}_tracked_flight_{tracker_key}"
+
+    @property
+    def flight(self) -> dict[str, Any]:
+        for flight in self.coordinator.flight.tracked_list:
+            if flight_tracker_key(flight) == self.tracker_key:
+                return flight
+        return {}
+
+    @property
+    def name(self) -> str:
+        flight = self.flight
+        if flight:
+            return f"Tracked flight {flight_display_name(flight)}"
+        return "Tracked flight"
+
+    @property
+    def native_value(self) -> str | None:
+        flight = self.flight
+        if not flight:
+            return None
+        return flight.get("tracked_type") or "tracked"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        flight = copy.deepcopy(self.flight)
+        if not flight:
+            return {"flights": [], "last_updated": datetime.datetime.now().isoformat()}
+        return {
+            "flights": [flight],
+            "flight": flight,
+            "last_updated": datetime.datetime.now().isoformat(),
+        }
+
+    @property
+    def available(self) -> bool:
+        return bool(self.flight)

--- a/custom_components/flightradar24/sensor.py
+++ b/custom_components/flightradar24/sensor.py
@@ -212,6 +212,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     @callback
     def add_tracked_flight_sensors() -> None:
         """Add one sensor per additional tracked flight."""
+        current_keys = {
+            tracker_key
+            for flight in coordinator.flight.tracked_list
+            if (tracker_key := flight_tracker_key(flight))
+        }
+        for tracker_key in set(tracked_sensors) - current_keys:
+            sensor = tracked_sensors.pop(tracker_key)
+            if entity_id := ent_reg.async_get_entity_id(
+                    "sensor",
+                    DOMAIN,
+                    FlightRadar24TrackedFlightSensor.unique_id(entry.entry_id, tracker_key),
+            ):
+                ent_reg.async_remove(entity_id)
+            hass.async_create_task(sensor.async_remove())
+
         new_entities: list[FlightRadar24TrackedFlightSensor] = []
         for flight in coordinator.flight.tracked_list:
             tracker_key = flight_tracker_key(flight)
@@ -296,7 +311,11 @@ class FlightRadar24TrackedFlightSensor(CoordinatorEntity[FlightRadar24Coordinato
         self.tracker_key = tracker_key
         super().__init__(coordinator)
         self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = f"{entry_id}_{DOMAIN}_tracked_flight_{tracker_key}"
+        self._attr_unique_id = self.unique_id(entry_id, tracker_key)
+
+    @staticmethod
+    def unique_id(entry_id: str, tracker_key: str) -> str:
+        return f"{entry_id}_{DOMAIN}_tracked_flight_{tracker_key}"
 
     @property
     def flight(self) -> dict[str, Any]:

--- a/custom_components/flightradar24/sensor.py
+++ b/custom_components/flightradar24/sensor.py
@@ -335,6 +335,7 @@ class FlightRadar24RestoreSensor(FlightRadar24Sensor, RestoreSensor):
 class FlightRadar24TrackedFlightSensor(CoordinatorEntity[FlightRadar24Coordinator], SensorEntity):
     _attr_has_entity_name = True
     _attr_icon = "mdi:airplane"
+    _attr_state_class = SensorStateClass.TOTAL
     _unrecorded_attributes = frozenset({"flights", "flight"})
 
     def __init__(
@@ -367,11 +368,11 @@ class FlightRadar24TrackedFlightSensor(CoordinatorEntity[FlightRadar24Coordinato
         return "Tracked flight"
 
     @property
-    def native_value(self) -> str | None:
+    def native_value(self) -> int | None:
         flight = self.flight
         if not flight:
             return None
-        return flight.get("tracked_type") or "tracked"
+        return 1
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -381,6 +382,7 @@ class FlightRadar24TrackedFlightSensor(CoordinatorEntity[FlightRadar24Coordinato
         return {
             "flights": [flight],
             "flight": flight,
+            "tracked_type": flight.get("tracked_type"),
             "last_updated": datetime.datetime.now().isoformat(),
         }
 

--- a/custom_components/flightradar24/sensor.py
+++ b/custom_components/flightradar24/sensor.py
@@ -183,11 +183,24 @@ RESTORE_SENSOR_TYPES: tuple[FlightRadar24SensorEntityDescription, ...] = (
 )
 
 
+@callback
+def _remove_bad_registry_entries(ent_reg: er.EntityRegistry) -> None:
+    """Remove entities created with a non-serializable unique ID."""
+    for entity_entry in list(ent_reg.entities.values()):
+        if (
+                entity_entry.domain == "sensor"
+                and entity_entry.platform == DOMAIN
+                and not isinstance(entity_entry.unique_id, str)
+        ):
+            ent_reg.async_remove(entity_entry.entity_id)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
     # --- DYNAMIC MIGRATION LOGIC TO PREVENT BREAKING CHANGES ---
     ent_reg = er.async_get(hass)
+    _remove_bad_registry_entries(ent_reg)
     for description in SENSOR_TYPES + RESTORE_SENSOR_TYPES:
         old_unique_id = f"{coordinator.unique_id}_{DOMAIN}_{description.key}"
         new_unique_id = f"{entry.entry_id}_{DOMAIN}_{description.key}"
@@ -222,10 +235,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             if entity_id := ent_reg.async_get_entity_id(
                     "sensor",
                     DOMAIN,
-                    FlightRadar24TrackedFlightSensor.unique_id(entry.entry_id, tracker_key),
+                    FlightRadar24TrackedFlightSensor.make_unique_id(entry.entry_id, tracker_key),
             ):
                 ent_reg.async_remove(entity_id)
-            hass.async_create_task(sensor.async_remove())
+            if sensor.hass is not None:
+                hass.async_create_task(sensor.async_remove())
 
         new_entities: list[FlightRadar24TrackedFlightSensor] = []
         for flight in coordinator.flight.tracked_list:
@@ -311,10 +325,10 @@ class FlightRadar24TrackedFlightSensor(CoordinatorEntity[FlightRadar24Coordinato
         self.tracker_key = tracker_key
         super().__init__(coordinator)
         self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = self.unique_id(entry_id, tracker_key)
+        self._attr_unique_id = self.make_unique_id(entry_id, tracker_key)
 
     @staticmethod
-    def unique_id(entry_id: str, tracker_key: str) -> str:
+    def make_unique_id(entry_id: str, tracker_key: str) -> str:
         return f"{entry_id}_{DOMAIN}_tracked_flight_{tracker_key}"
 
     @property

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,7 @@
 {
   "name": "Flightradar24",
+  "filename": "flightradar24.zip",
   "homeassistant": "2023.9.3",
-  "render_readme": true
+  "render_readme": true,
+  "zip_release": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,5 @@
 {
   "name": "Flightradar24",
-  "filename": "flightradar24.zip",
   "homeassistant": "2023.9.3",
-  "render_readme": true,
-  "zip_release": true
+  "render_readme": true
 }


### PR DESCRIPTION
I wanted to have device trackers for a few flights. Originally, I used multiple instances of the integration. 
However, I ran into the issue of running out of file descriptors due to the fact that this integration uses quite a lot of them, and it quickly adds up. 
This PR mitigates that problem so one integration can track them all. It creates an extra sensor and device tracker whenever an additional tracked flight is added, then removes it if it is no longer additionally tracked. It also preserves integration with the [flightradar-flight-card](https://github.com/plckr/flightradar-flight-card).