### PR TITLE
Detect and replace sessions that only receive empty feed data (#278, #271)

### DIFF
--- a/custom_components/flightradar24/__init__.py
+++ b/custom_components/flightradar24/__init__.py
@@ -3,8 +3,9 @@ from logging import getLogger
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from .const import DOMAIN
-from .coordinator import FlightRadar24Coordinator
+from homeassistant.exceptions import ConfigEntryNotReady
+from .const import DOMAIN, SESSION_SETUP_MAX_TRIES
+from .coordinator import FlightRadar24Coordinator, is_session_healthy
 from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
@@ -42,9 +43,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
 
-    client = FlightRadar24API()
-    if username and password:
-        await hass.async_add_executor_job(client.login, username, password)
+    async def create_client() -> FlightRadar24API:
+        new_client = FlightRadar24API()
+        if username and password:
+            await hass.async_add_executor_job(new_client.login, username, password)
+        return new_client
+
+    client = await create_client()
+
+    # FR24's bot mitigation randomly hands out sessions that only ever receive
+    # valid but empty feed responses, and a session keeps that fate for its
+    # entire lifetime (#278, #271). Verify the session before using it.
+    for attempt in range(1, SESSION_SETUP_MAX_TRIES + 1):
+        try:
+            healthy = await hass.async_add_executor_job(is_session_healthy, client)
+        except Exception as e:
+            raise ConfigEntryNotReady('FlightRadar24 is not reachable: {}'.format(e)) from e
+        if healthy:
+            break
+        _LOGGER.warning(
+            'FlightRadar24: got an empty session (bot mitigation), recreating (%d/%d)',
+            attempt, SESSION_SETUP_MAX_TRIES,
+        )
+        client = await create_client()
+    else:
+        raise ConfigEntryNotReady(
+            'FlightRadar24 keeps handing out empty sessions (bot mitigation), retrying setup later'
+        )
 
     latitude = entry.data[CONF_LATITUDE]
     longitude = entry.data[CONF_LONGITUDE]

--- a/custom_components/flightradar24/api/airport.py
+++ b/custom_components/flightradar24/api/airport.py
@@ -32,6 +32,9 @@ class AirportProcessor:
         self._arrivals: list[dict[str, Any]] | None = None
         self._departures: list[dict[str, Any]] | None = None
 
+    def update_client(self, client: FlightRadar24API) -> None:
+        self._client = client
+
     @property
     def code(self) -> str | None:
         return self._code

--- a/custom_components/flightradar24/api/flight.py
+++ b/custom_components/flightradar24/api/flight.py
@@ -77,7 +77,7 @@ class FlightType(Enum):
 
 class FlightProcessor:
     __slots__ = ('_in_area', '_tracked', '_most_tracked', '_entered', '_exited', '_min_altitude', '_max_altitude',
-                 '_point', '_client', '_bounds', '_event_manager', '_auto_cleanup')
+                 '_point', '_client', '_bounds', '_event_manager', '_auto_cleanup', '_raw_in_area_count')
 
     def __init__(
             self,
@@ -101,6 +101,18 @@ class FlightProcessor:
         self._most_tracked: dict[str, dict[str, Any]] | None = None
         self._entered: list[dict[str, Any]] = []
         self._exited: list[dict[str, Any]] = []
+        self._raw_in_area_count: int = 0
+
+    @property
+    def client(self) -> FlightRadar24API:
+        return self._client
+
+    @property
+    def raw_in_area_count(self) -> int:
+        return self._raw_in_area_count
+
+    def update_client(self, client: FlightRadar24API) -> None:
+        self._client = client
 
     @property
     def tracked(self) -> dict[str, dict[str, Any]]:
@@ -169,6 +181,9 @@ class FlightProcessor:
         self._entered = {}
         self._exited = {}
         flights = self._client.get_flights(bounds=self._bounds)
+        # Unfiltered count for the session guard (see coordinator) - altitude
+        # filtering below must not hide traffic from the empty-session detection.
+        self._raw_in_area_count = len(flights)
         current: dict[str, dict[str, Any]] = {}
         for obj in flights:
             if not self._min_altitude <= obj.altitude <= self._max_altitude:

--- a/custom_components/flightradar24/const.py
+++ b/custom_components/flightradar24/const.py
@@ -35,3 +35,18 @@ EVENT_TRACKED_LEFT_GATE = f"{DOMAIN}_tracked_left_gate"
 
 MIN_ALTITUDE = -1
 MAX_ALTITUDE = 100000
+
+# FR24's bot mitigation can hand out a session that only ever receives valid
+# but empty feed responses, and a session keeps that fate for its entire
+# lifetime (issues #278 / #271). A session is considered healthy when it sees
+# traffic in at least one of these bounds (y1,y2,x1,x2) - regions busy enough
+# that a healthy session never finds all of them empty, no matter the time of day.
+CANARY_BOUNDS = [
+    '54.0,44.0,-2.0,20.0',    # Central/Western Europe
+    '42.0,30.0,-95.0,-75.0',  # US East
+]
+SESSION_SETUP_MAX_TRIES = 5
+# Runtime guard: only canary-check when the area feed has been empty this long,
+# and at most once per throttle window, to keep extra API calls negligible.
+SESSION_GUARD_EMPTY_SECONDS = 1800
+SESSION_GUARD_CHECK_THROTTLE = 1800

--- a/custom_components/flightradar24/coordinator.py
+++ b/custom_components/flightradar24/coordinator.py
@@ -1,20 +1,38 @@
 from __future__ import annotations
 from datetime import timedelta
+from time import monotonic
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from .const import (
     DOMAIN,
     URL,
     DEFAULT_NAME,
     CONF_AUTO_CLEANUP,
     CONF_AUTO_CLEANUP_DEFAULT,
+    CANARY_BOUNDS,
+    SESSION_GUARD_EMPTY_SECONDS,
+    SESSION_GUARD_CHECK_THROTTLE,
 )
 from .api.event import EventManager, Event
 from .api.flight import FlightProcessor
 from .api.airport import AirportProcessor
 from logging import Logger
 from FlightRadar24 import FlightRadar24API, Entity
+
+
+def is_session_healthy(client: FlightRadar24API) -> bool:
+    """Blocking canary check for the sticky empty-session issue (#278, #271).
+
+    FR24's bot mitigation randomly hands out sessions that only ever receive
+    valid but empty feed responses. A healthy session sees traffic in at least
+    one of the known-busy canary regions.
+    """
+    for bounds in CANARY_BOUNDS:
+        if client.get_flights(bounds=bounds):
+            return True
+    return False
 
 
 class FlightRadar24Coordinator(DataUpdateCoordinator[int]):
@@ -37,6 +55,8 @@ class FlightRadar24Coordinator(DataUpdateCoordinator[int]):
         self.airport = AirportProcessor(client)
         self.enable_tracker: bool = False
         self.scanning: bool = True
+        self._guard_last_seen: float = monotonic()
+        self._guard_last_check: float = 0.0
         self.device_info = DeviceInfo(
             configuration_url=URL,
             identifiers={(DOMAIN, self.unique_id)},
@@ -98,6 +118,7 @@ class FlightRadar24Coordinator(DataUpdateCoordinator[int]):
             await self.hass.async_add_executor_job(self.flight.update_flights_tracked)
             await self.hass.async_add_executor_job(self.flight.update_most_tracked)
             await self.hass.async_add_executor_job(self.airport.update_airport_info)
+            await self._check_session()
         except Exception as e:
             self.logger.error("FlightRadar24: %s", e)
 
@@ -105,3 +126,35 @@ class FlightRadar24Coordinator(DataUpdateCoordinator[int]):
             self.hass.bus.fire(event.event, event.data)
 
         self.event_manager.fire_events(self.config_entry.title, fire)
+
+    def _renew_client(self) -> FlightRadar24API:
+        client = FlightRadar24API()
+        username = self.config_entry.data.get(CONF_USERNAME)
+        password = self.config_entry.data.get(CONF_PASSWORD)
+        if username and password:
+            client.login(username, password)
+        return client
+
+    async def _check_session(self) -> None:
+        """Detect a session gone sticky-empty at runtime and replace it (#278).
+
+        Cheap by design: no extra requests at all while the area feed sees
+        traffic; once it has been empty for SESSION_GUARD_EMPTY_SECONDS, run
+        the canary at most once per SESSION_GUARD_CHECK_THROTTLE.
+        """
+        now = monotonic()
+        if self.flight.raw_in_area_count > 0:
+            self._guard_last_seen = now
+            return
+        if (now - self._guard_last_seen < SESSION_GUARD_EMPTY_SECONDS
+                or now - self._guard_last_check < SESSION_GUARD_CHECK_THROTTLE):
+            return
+        self._guard_last_check = now
+        if await self.hass.async_add_executor_job(is_session_healthy, self.flight.client):
+            return
+        self.logger.warning(
+            'FlightRadar24: session only receives empty feed data (bot mitigation), recreating session'
+        )
+        client = await self.hass.async_add_executor_job(self._renew_client)
+        self.flight.update_client(client)
+        self.airport.update_client(client)


### PR DESCRIPTION
Fixes #278, most likely also fixes #271.

## Problem

FR24's bot mitigation decides **at session creation** whether a session receives real feed data or valid-but-empty responses (HTTP 200, correct JSON structure, `full_count` populated, but zero visible aircraft) — and the session keeps that fate for its **entire lifetime**. Reproduction from #278: six fresh requests against the same busy bounds returned `22, 22, 0, 0, 22, 0` flights; requests within one keep-alive session were consistent.

Since the integration creates one `FlightRadar24API` client at setup and keeps it forever, an unlucky session means all area sensors silently freeze at `0` **with no error logged** — in my case for three days straight — until the user happens to reload the config entry (which is itself a coin flip).

## Approach

Two defenses, both at the integration level, since "this response should not be empty" is an application-level judgment and the integration owns the client lifecycle:

1. **Setup canary** (`__init__.py`): after creating the client, verify it sees traffic in at least one of two known-busy canary regions (Central/Western Europe and US East — never both empty at any hour). If not, recreate the client (including re-login for premium users), up to 5 attempts. If all attempts return empty, raise `ConfigEntryNotReady` so HA retries setup with backoff instead of running blind.

2. **Runtime guard** (`coordinator.py`): if the configured area has seen **zero raw aircraft** (before altitude filtering) for 30 minutes, run the same canary — throttled to at most once per 30 minutes. If the canary comes back empty, log a warning and transparently swap a freshly created client into `FlightProcessor` and `AirportProcessor` via a new `update_client()`. This also covers sessions that go bad *after* setup.

## Cost

- Zero extra API calls while the area feed sees any traffic.
- At most 2 canary requests per 30 minutes while the area is (legitimately or not) empty.
- Setup: 1–2 extra requests per attempt.

## Testing

- Canary check verified against the live API with the pinned `FlightRadarAPI==1.5.1` (returns `True` on a healthy session; empty sessions reproduce with roughly 1-in-5 probability from my network).
- Running in production on my own instance (HA 2026.7.2) since 2026-07-19. On the very first startup the setup canary already caught a real empty session and replaced it:
  ```
  WARNING [custom_components.flightradar24] FlightRadar24: got an empty session (bot mitigation), recreating (1/5)
  ```
  The integration then came up with a working session.
- End-to-end verified live: after temporarily widening the radius to 50 km, the `current_in_area` sensor immediately reported 4 real flights with full details (route, aircraft, photos) — so a canary-approved session demonstrably delivers data all the way into the sensor attributes. Two further config-triggered reloads both passed the canary silently and came up healthy.
- The runtime guard (session going empty *mid-flight*) cannot be forced from the outside since FR24 controls when a session goes bad; it shares the same `is_session_healthy()` + client-swap code path as the setup canary, though. I'll report back after some real-world runtime.
- No changes to config flow, entities, or stored data.