### PR TITLE
Survive Flightradar24 rate limiting instead of losing the whole update

### DIFF
--- a/custom_components/flightradar24/__init__.py
+++ b/custom_components/flightradar24/__init__.py
@@ -44,7 +44,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     client = FlightRadar24API()
     if username and password:
-        await hass.async_add_executor_job(client.login, username, password)
+        try:
+            await hass.async_add_executor_job(client.login, username, password)
+        except Exception as error:
+            # Logging in is optional - Flightradar24 serves the feed anonymously
+            # too. Failing the whole setup here turns a transient error such as
+            # HTTP 429 into a permanent "setup_error" that Home Assistant never
+            # retries, so carry on unauthenticated instead.
+            _LOGGER.warning(
+                'FlightRadar24: could not log in, continuing anonymously - %s',
+                error,
+            )
 
     latitude = entry.data[CONF_LATITUDE]
     longitude = entry.data[CONF_LONGITUDE]

--- a/custom_components/flightradar24/api/flight.py
+++ b/custom_components/flightradar24/api/flight.py
@@ -1,4 +1,6 @@
 import re
+import time
+from logging import getLogger
 from typing import Any
 from enum import Enum
 from FlightRadar24 import FlightRadar24API, Flight, Entity
@@ -14,8 +16,14 @@ from ..const import (
     EVENT_MOST_TRACKED_NEW,
     EVENT_TRACKED_ARRIVED_GATE,
     EVENT_TRACKED_LEFT_GATE,
+    DETAIL_REQUEST_INTERVAL,
+    DETAIL_REQUEST_ATTEMPTS,
+    DETAIL_RETRY_BASE_DELAY,
+    EMPTY_FEED_WARNING_THRESHOLD,
 )
 import pycountry
+
+_LOGGER = getLogger(__name__)
 
 
 def is_helicopter(flight) -> bool:
@@ -77,7 +85,8 @@ class FlightType(Enum):
 
 class FlightProcessor:
     __slots__ = ('_in_area', '_tracked', '_most_tracked', '_entered', '_exited', '_min_altitude', '_max_altitude',
-                 '_point', '_client', '_bounds', '_event_manager', '_auto_cleanup')
+                 '_point', '_client', '_bounds', '_event_manager', '_auto_cleanup', '_last_detail_request',
+                 '_empty_responses')
 
     def __init__(
             self,
@@ -101,6 +110,8 @@ class FlightProcessor:
         self._most_tracked: dict[str, dict[str, Any]] | None = None
         self._entered: list[dict[str, Any]] = []
         self._exited: list[dict[str, Any]] = []
+        self._last_detail_request: float = 0.0
+        self._empty_responses: int = 0
 
     @property
     def tracked(self) -> dict[str, dict[str, Any]]:
@@ -169,6 +180,7 @@ class FlightProcessor:
         self._entered = {}
         self._exited = {}
         flights = self._client.get_flights(bounds=self._bounds)
+        self._check_empty_feed(flights)
         current: dict[str, dict[str, Any]] = {}
         for obj in flights:
             if not self._min_altitude <= obj.altitude <= self._max_altitude:
@@ -183,6 +195,25 @@ class FlightProcessor:
             self._event_manager.add_events(EVENT_ENTRY, self._entered)
             self._event_manager.add_events(EVENT_EXIT, self._exited)
         self._in_area = current
+
+    def _check_empty_feed(self, flights: list[Flight]) -> None:
+        """Warn when Flightradar24 keeps answering with an empty feed.
+
+        A throttled client is served HTTP 200 with no aircraft rather than an
+        error, so the integration would silently report zero flights forever.
+        """
+        if flights:
+            self._empty_responses = 0
+            return
+
+        self._empty_responses += 1
+        if self._empty_responses == EMPTY_FEED_WARNING_THRESHOLD:
+            _LOGGER.warning(
+                'FlightRadar24: Flightradar24 has returned no aircraft for %s consecutive updates. '
+                'This usually means the requests are being throttled. Consider increasing the update '
+                'interval, reducing the radius or raising the minimum altitude.',
+                EMPTY_FEED_WARNING_THRESHOLD,
+            )
 
     def update_flights_tracked(self) -> None:
         if not self._tracked:
@@ -297,7 +328,8 @@ class FlightProcessor:
                 'flight_number': found['detail'].get('flight'),
                 'aircraft_registration': None,
             }
-        current[found.get('id')]['tracked_type'] = found.get('type')
+        if found.get('id') in current:
+            current[found.get('id')]['tracked_type'] = found.get('type')
 
     def update_most_tracked(self) -> None:
         if self._most_tracked is None:
@@ -323,6 +355,30 @@ class FlightProcessor:
         self._most_tracked = current
         self._event_manager.add_events(EVENT_MOST_TRACKED_NEW, entries)
 
+    def _get_flight_details(self, obj: Flight) -> dict | None:
+        """Fetch the details of a single flight.
+
+        Flightradar24 rejects bursts of detail requests, so the lookups are
+        spaced out and retried with a backoff. ``None`` is returned when the
+        details cannot be fetched, which lets the caller keep the rest of the
+        update instead of losing it to a single failed request.
+        """
+        for attempt in range(DETAIL_REQUEST_ATTEMPTS):
+            elapsed = time.monotonic() - self._last_detail_request
+            if elapsed < DETAIL_REQUEST_INTERVAL:
+                time.sleep(DETAIL_REQUEST_INTERVAL - elapsed)
+            self._last_detail_request = time.monotonic()
+
+            try:
+                return self._client.get_flight_details(obj)
+            except Exception as error:
+                if attempt == DETAIL_REQUEST_ATTEMPTS - 1:
+                    _LOGGER.warning('FlightRadar24: Could not get details of flight %s - %s', obj.id, error)
+                    return None
+                time.sleep(DETAIL_RETRY_BASE_DELAY * (2 ** attempt))
+
+        return None
+
     def _update_flights_data(self,
                              obj: Flight,
                              current: dict[str, dict[str, Any]],
@@ -338,8 +394,14 @@ class FlightProcessor:
                 and to_int(last_position) == obj.on_ground):
             flight = tracked[obj.id]
         else:
-            data = self._client.get_flight_details(obj)
-            flight = self._get_flight_data(data)
+            data = self._get_flight_details(obj)
+            if data is None:
+                # Details are unavailable for now - keep whatever is already known
+                # about the flight, or skip it until the next update, instead of
+                # aborting the whole cycle.
+                flight = previous_flight
+            else:
+                flight = self._get_flight_data(data)
         if flight is not None:
             current[flight['id']] = flight
             flight['latitude'] = obj.latitude

--- a/custom_components/flightradar24/const.py
+++ b/custom_components/flightradar24/const.py
@@ -35,3 +35,15 @@ EVENT_TRACKED_LEFT_GATE = f"{DOMAIN}_tracked_left_gate"
 
 MIN_ALTITUDE = -1
 MAX_ALTITUDE = 100000
+
+# Flightradar24 rate limits clients that request flight details too quickly.
+# Space the per-flight detail lookups out and retry them with a backoff instead
+# of letting a single failure abort the whole update cycle.
+DETAIL_REQUEST_INTERVAL = 0.5
+DETAIL_REQUEST_ATTEMPTS = 3
+DETAIL_RETRY_BASE_DELAY = 2
+
+# When a client is throttled, Flightradar24 answers with HTTP 200 and an empty
+# feed instead of an error, which is indistinguishable from "no aircraft".
+# Warn once the feed has been empty for this many consecutive updates.
+EMPTY_FEED_WARNING_THRESHOLD = 5

--- a/custom_components/flightradar24/translations/en.json
+++ b/custom_components/flightradar24/translations/en.json
@@ -8,6 +8,10 @@
           "latitude": "Latitude",
           "longitude": "Longitude",
           "scan_interval": "Update interval in seconds"
+        },
+        "data_description": {
+          "radius": "Radius of the monitored area in meters, not kilometers. For example, enter 25000 for a 25 km radius.",
+          "scan_interval": "How often Flightradar24 is polled. Short intervals make it more likely that your requests get throttled."
         }
       }
     }
@@ -29,6 +33,11 @@
           "tracker_name_style": "Map Tracker Naming Style",
           "username": "Username (Optional)",
           "password": "Password (Optional)"
+        },
+        "data_description": {
+          "radius": "Radius of the monitored area in meters, not kilometers. For example, enter 25000 for a 25 km radius.",
+          "scan_interval": "How often Flightradar24 is polled. Short intervals make it more likely that your requests get throttled.",
+          "min_altitude": "Aircraft below this altitude are ignored. Raising it reduces the number of requests made to Flightradar24."
         }
       }
     }


### PR DESCRIPTION
## Problem

The integration issues one extra `get_flight_details()` HTTP request **per new aircraft, per update**. Flightradar24 rejects bursts of these requests, and because `FlightRadarAPI`'s `RetryPolicy` defaults to `max_attempts=1` there is no backoff, so the first rejection propagates straight out of `update_flights_in_area()`.

That happens **before** `self._in_area = current` on the last line of the method, so the previous state is never replaced. Every aircraft is therefore "new" again on the next update, which triggers the same burst, which fails again. The sensor gets stuck at `0`, no `flightradar24_entry` / `flightradar24_exit` events are fired, and the only symptom is a single repeating line from `coordinator.py`:

```
ERROR (MainThread) [custom_components.flightradar24] FlightRadar24: HTTP Error 429:
```

I reproduced this outside Home Assistant against a 25 km area with ~26 aircraft. Detail lookups succeed for the first few flights and are then rejected:

```
 1 BAUC   OK   t= 0.1s
 ...
 6 GDDRJ  OK   t= 0.6s
 7 GDEDU  FAIL HTTPError: HTTP Error 429:   t= 0.7s
```

It gets worse. Once a client has been throttled, Flightradar24 stops returning errors and instead answers `feed.js` with **HTTP 200 and an empty feed**:

```json
{"full_count": 22684, "version": 4,
 "stats": {"total": {"ads-b": 18541, "mlat": 1453, ...},
           "visible": {"ads-b": 0, "mlat": 0, "faa": 0, "flarm": 0,
                       "estimated": 0, "satellite": 0, "uat": 0, "other": 0}}}
```

`get_flights()` returns `[]`, no exception is raised and nothing is logged, so this is indistinguishable from "there are genuinely no aircraft in the area". In my case the sensor sat at `0` for over half an hour with a completely clean log while an identical query from another process on the same public IP was returning 12-14 aircraft.

## Changes

**`api/flight.py`**

- `_get_flight_details()` — new wrapper around `client.get_flight_details()` that spaces consecutive detail lookups at least `DETAIL_REQUEST_INTERVAL` apart and retries `DETAIL_REQUEST_ATTEMPTS` times with an exponential backoff.
- On persistent failure it returns `None` and logs a warning naming the flight, instead of raising. `_update_flights_data()` then reuses the previously known data for that flight, or skips it until the next update. Either way `update_flights_in_area()` runs to completion and `self._in_area` is always assigned, so one unlucky aircraft can no longer cost the entire update.
- `_check_empty_feed()` — logs a warning once the feed has come back empty for `EMPTY_FEED_WARNING_THRESHOLD` consecutive updates, so throttling is visible in the log rather than silent.
- `_find_flight()` — guard the `current[found.get('id')]['tracked_type'] = ...` assignment. If `_update_flights_data()` does not add the flight (which was already possible when `_get_flight_data()` returned `None`) this raised `KeyError`.

**`const.py`** — the four new tunables, with comments explaining why they exist.

**`translations/en.json`** — added `data_description` entries. `radius` is in metres, which is easy to miss: a user entering `25` expecting kilometres gets a 25 metre area and a sensor that reads `0` forever with no error anywhere. The `scan_interval` and `min_altitude` descriptions point out their effect on request volume.

Only `en.json` is touched; the other locales are left for translators.

## Not included, but worth considering

- `config_flow.py` still defaults `scan_interval` to `10` seconds and `radius` to `1000`. A 10 second poll is a significant contributor to being throttled, and a 1 km radius rarely produces any aircraft. Happy to raise defaults in this PR or a separate one if you'd like.
- `FlightRadar24API()` is constructed in `__init__.py` without a `RetryPolicy`. Passing `RetryPolicy(max_attempts=3)` would additionally cover `get_flights()`, `search()` and `get_most_tracked()`. I left it out to keep the retry behaviour in one place, but it may be the tidier fix.

## Testing

- `python -m compileall custom_components/flightradar24` passes; `en.json` parses.
- Ran the patched integration against a 25 km / 5000 ft area. Before: sensor pinned at `0`, `HTTP Error 429` every update. After: sensor tracks 2-7 aircraft per update, `flightradar24_entry` events fire normally, no errors.
