### PR TITLE
Harden request throttling and startup behavior (follow-up to #285)

### DIFF
--- a/custom_components/flightradar24/__init__.py
+++ b/custom_components/flightradar24/__init__.py
@@ -98,6 +98,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
+    # Kick off the first refresh without blocking setup - entities register
+    # immediately and fill as soon as the first cycle completes, instead of
+    # waiting up to scan_interval for the first scheduled tick.
+    entry.async_create_background_task(hass, coordinator.async_refresh(), 'flightradar24_initial_refresh')
+
     return True
 
 

--- a/custom_components/flightradar24/api/client.py
+++ b/custom_components/flightradar24/api/client.py
@@ -3,18 +3,22 @@ from ..const import (
     REQUEST_INTERVAL,
     REQUEST_ATTEMPTS,
     RETRY_BASE_DELAY,
+    FAILURE_COOLDOWN,
 )
 from logging import Logger
+from threading import Lock
 from time import sleep, monotonic
 
 
 class FlightRadarClient:
-    __slots__ = ('_client', '_logger', '_last_request')
+    __slots__ = ('_client', '_logger', '_last_request', '_lock', '_broken_until')
 
     def __init__(self, client: FlightRadar24API, logger: Logger) -> None:
         self._client = client
         self._logger = logger
         self._last_request: float = 0.0
+        self._lock = Lock()
+        self._broken_until: float = 0.0
 
     def get_airport_details(self, code: str) -> dict:
         return self._request('get_airport_details', code)
@@ -32,17 +36,24 @@ class FlightRadarClient:
         return self._request('get_most_tracked')
 
     def _request(self, method_name: str, *args, **kwargs) -> dict:
+        if monotonic() < self._broken_until:
+            raise ConnectionError('unreachable, in cooldown after repeated failures')
+
         for attempt in range(REQUEST_ATTEMPTS):
-            elapsed = monotonic() - self._last_request
-            if elapsed < REQUEST_INTERVAL:
-                sleep(REQUEST_INTERVAL - elapsed)
-            self._last_request = monotonic()
+            # Hold the lock only for the spacing gate, not the HTTP call,
+            # so a slow request does not serialize the other callers.
+            with self._lock:
+                elapsed = monotonic() - self._last_request
+                if elapsed < REQUEST_INTERVAL:
+                    sleep(REQUEST_INTERVAL - elapsed)
+                self._last_request = monotonic()
 
             try:
                 method = getattr(self._client, method_name)
                 return method(*args, **kwargs)
             except Exception as e:
                 if attempt == REQUEST_ATTEMPTS - 1:
+                    self._broken_until = monotonic() + FAILURE_COOLDOWN
                     self._logger.warning('FlightRadar24: Could not get details for %s - %s', method_name, e)
                     raise e
                 sleep(RETRY_BASE_DELAY * (2 ** attempt))

--- a/custom_components/flightradar24/const.py
+++ b/custom_components/flightradar24/const.py
@@ -57,3 +57,6 @@ SESSION_GUARD_CHECK_THROTTLE = 1800
 REQUEST_INTERVAL = 0.2
 REQUEST_ATTEMPTS = 3
 RETRY_BASE_DELAY = 2
+# Once a request has exhausted its retries, fail fast for this long instead of
+# letting every remaining call of the cycle burn its own backoff (circuit breaker).
+FAILURE_COOLDOWN = 30


### PR DESCRIPTION
Follow-up to the discussion in #285, as requested:

- **Lock around the pacing gate** in `FlightRadarClient._request` — held only for the spacing check + timestamp, not the HTTP call, so a slow request doesn't serialize other callers. Closes the race where the service paths (`add_track`, `search`) could slip past the interval alongside the update cycle.
- **Failure cooldown** (a small circuit breaker): once a request has exhausted its retries, the wrapper fails fast for `FAILURE_COOLDOWN = 30` s instead of every remaining call of the cycle burning its own 2+4 s backoff. An outage cycle now costs ~6 s once instead of ~25 s of blocked executor time — the coordinator picks up again on a later tick anyway.
- **Initial refresh as a background task** in `async_setup_entry`: setup stays non-blocking (the reason `first_refresh` was removed in #285), but entities fill as soon as the first cycle completes instead of waiting up to `scan_interval` for the first scheduled tick.

Verified offline against a fake client: 6 concurrent callers get spaced at 0.20 s with no slip-through, a single transient failure recovers after the 2 s backoff, and a full outage costs 6.0 s once with subsequent calls failing in <1 ms with a clear message. Happy to run it on my instance alongside the v1.34.4b1 test as well.