### PR TITLE
Bug fix for Current in the Area, Entered Area and Exited Area sensors are always 0 problem and problem unavailable sensors at start

### DIFF
--- a/custom_components/flightradar24/__init__.py
+++ b/custom_components/flightradar24/__init__.py
@@ -55,27 +55,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # FR24's bot mitigation randomly hands out sessions that only ever receive
     # valid but empty feed responses, and a session keeps that fate for its
     # entire lifetime (#278, #271). Verify the session before using it.
+    session_verified = False
     for attempt in range(1, SESSION_SETUP_MAX_TRIES + 1):
         try:
-            healthy = await hass.async_add_executor_job(is_session_healthy, client)
+            session_verified = await hass.async_add_executor_job(is_session_healthy, client)
         except Exception as e:
             raise ConfigEntryNotReady('FlightRadar24 is not reachable: {}'.format(e)) from e
-        if healthy:
+        if session_verified:
             break
         _LOGGER.warning(
             'FlightRadar24: got an empty session (bot mitigation), recreating (%d/%d)',
             attempt, SESSION_SETUP_MAX_TRIES,
         )
         client = await create_client()
-    else:
-        raise ConfigEntryNotReady(
-            'FlightRadar24 keeps handing out empty sessions (bot mitigation), retrying setup later'
+
+    if not session_verified:
+        # Deliberately not ConfigEntryNotReady: FR24 is reachable, only this
+        # session is suspect. Failing setup would send HA into its 5/10/20/40s
+        # retry backoff and leave every entity unavailable for minutes after a
+        # restart. Carry on - the coordinator's guard renews the session on the
+        # first empty cycle instead.
+        _LOGGER.warning(
+            'FlightRadar24: could not verify the session during setup (bot mitigation), '
+            'continuing - the runtime session guard will renew it if it stays empty'
         )
 
     latitude = entry.data[CONF_LATITUDE]
     longitude = entry.data[CONF_LONGITUDE]
 
     bounds = client.get_bounds_by_point(latitude, longitude, entry.data[CONF_RADIUS])
+
+    # A cleared optional field is stored as None, and `None <= altitude` raises -
+    # which used to abort the whole area update and pin the counts to 0.
+    min_altitude = entry.data.get(CONF_MIN_ALTITUDE)
+    max_altitude = entry.data.get(CONF_MAX_ALTITUDE)
 
     coordinator = FlightRadar24Coordinator(
         hass,
@@ -84,9 +97,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data[CONF_SCAN_INTERVAL],
         _LOGGER,
         entry.entry_id,
-        entry.data.get(CONF_MIN_ALTITUDE, MIN_ALTITUDE),
-        entry.data.get(CONF_MAX_ALTITUDE, MAX_ALTITUDE),
+        MIN_ALTITUDE if min_altitude is None else int(min_altitude),
+        MAX_ALTITUDE if max_altitude is None else int(max_altitude),
         Entity(latitude, longitude),
+        session_verified,
     )
 
     if entry.data.get(CONF_MOST_TRACKED, CONF_MOST_TRACKED_DEFAULT):

--- a/custom_components/flightradar24/api/airport.py
+++ b/custom_components/flightradar24/api/airport.py
@@ -97,7 +97,7 @@ class AirportProcessor:
         flights = []
         airport = 'origin' if schedule == ScheduleType.ARRIVAL else 'destination'
         i = 0
-        for item in data:
+        for item in (data or []):
             i += 1
             item = get_value(item, ['flight'])
             flights.append({

--- a/custom_components/flightradar24/api/client.py
+++ b/custom_components/flightradar24/api/client.py
@@ -4,6 +4,7 @@ from ..const import (
     REQUEST_ATTEMPTS,
     RETRY_BASE_DELAY,
     FAILURE_COOLDOWN,
+    DETAILS_REQUEST_ATTEMPTS,
 )
 from logging import Logger
 from threading import Lock
@@ -18,7 +19,11 @@ class FlightRadarClient:
         self._logger = logger
         self._last_request: float = 0.0
         self._lock = Lock()
-        self._broken_until: float = 0.0
+        # Per endpoint, not global: get_flight_details is rate limited long
+        # before the area feed is, and a shared breaker would stop the feed as
+        # well - which is what leaves the in area / entered / exited sensors
+        # sitting at 0 for as long as the details endpoint is unhappy.
+        self._broken_until: dict[str, float] = {}
 
     def get_airport_details(self, code: str) -> dict:
         return self._request('get_airport_details', code)
@@ -27,7 +32,7 @@ class FlightRadarClient:
         return self._request('get_flights', **kwargs)
 
     def get_flight_details(self, obj: Flight) -> dict:
-        return self._request('get_flight_details', obj)
+        return self._request('get_flight_details', obj, attempts=DETAILS_REQUEST_ATTEMPTS)
 
     def search(self, number: str) -> dict:
         return self._request('search', number)
@@ -35,11 +40,12 @@ class FlightRadarClient:
     def get_most_tracked(self) -> dict:
         return self._request('get_most_tracked')
 
-    def _request(self, method_name: str, *args, **kwargs) -> dict:
-        if monotonic() < self._broken_until:
-            raise ConnectionError('unreachable, in cooldown after repeated failures')
+    def _request(self, method_name: str, *args, attempts: int = REQUEST_ATTEMPTS, **kwargs) -> dict:
+        broken_until = self._broken_until.get(method_name, 0.0)
+        if monotonic() < broken_until:
+            raise ConnectionError('{} is in cooldown after repeated failures'.format(method_name))
 
-        for attempt in range(REQUEST_ATTEMPTS):
+        for attempt in range(attempts):
             # Hold the lock only for the spacing gate, not the HTTP call,
             # so a slow request does not serialize the other callers.
             with self._lock:
@@ -50,12 +56,15 @@ class FlightRadarClient:
 
             try:
                 method = getattr(self._client, method_name)
-                return method(*args, **kwargs)
+                result = method(*args, **kwargs)
             except Exception as e:
-                if attempt == REQUEST_ATTEMPTS - 1:
-                    self._broken_until = monotonic() + FAILURE_COOLDOWN
+                if attempt == attempts - 1:
+                    self._broken_until[method_name] = monotonic() + FAILURE_COOLDOWN
                     self._logger.warning('FlightRadar24: Could not get details for %s - %s', method_name, e)
                     raise e
                 sleep(RETRY_BASE_DELAY * (2 ** attempt))
+            else:
+                self._broken_until.pop(method_name, None)
+                return result
 
         return None

--- a/custom_components/flightradar24/api/client.py
+++ b/custom_components/flightradar24/api/client.py
@@ -3,7 +3,6 @@ from ..const import (
     REQUEST_INTERVAL,
     REQUEST_ATTEMPTS,
     RETRY_BASE_DELAY,
-    FAILURE_COOLDOWN,
     DETAILS_REQUEST_ATTEMPTS,
 )
 from logging import Logger
@@ -12,18 +11,13 @@ from time import sleep, monotonic
 
 
 class FlightRadarClient:
-    __slots__ = ('_client', '_logger', '_last_request', '_lock', '_broken_until')
+    __slots__ = ('_client', '_logger', '_last_request', '_lock')
 
     def __init__(self, client: FlightRadar24API, logger: Logger) -> None:
         self._client = client
         self._logger = logger
         self._last_request: float = 0.0
         self._lock = Lock()
-        # Per endpoint, not global: get_flight_details is rate limited long
-        # before the area feed is, and a shared breaker would stop the feed as
-        # well - which is what leaves the in area / entered / exited sensors
-        # sitting at 0 for as long as the details endpoint is unhappy.
-        self._broken_until: dict[str, float] = {}
 
     def get_airport_details(self, code: str) -> dict:
         return self._request('get_airport_details', code)
@@ -41,10 +35,6 @@ class FlightRadarClient:
         return self._request('get_most_tracked')
 
     def _request(self, method_name: str, *args, attempts: int = REQUEST_ATTEMPTS, **kwargs) -> dict:
-        broken_until = self._broken_until.get(method_name, 0.0)
-        if monotonic() < broken_until:
-            raise ConnectionError('{} is in cooldown after repeated failures'.format(method_name))
-
         for attempt in range(attempts):
             # Hold the lock only for the spacing gate, not the HTTP call,
             # so a slow request does not serialize the other callers.
@@ -59,12 +49,10 @@ class FlightRadarClient:
                 result = method(*args, **kwargs)
             except Exception as e:
                 if attempt == attempts - 1:
-                    self._broken_until[method_name] = monotonic() + FAILURE_COOLDOWN
                     self._logger.warning('FlightRadar24: Could not get details for %s - %s', method_name, e)
                     raise e
                 sleep(RETRY_BASE_DELAY * (2 ** attempt))
             else:
-                self._broken_until.pop(method_name, None)
                 return result
 
         return None

--- a/custom_components/flightradar24/api/flight.py
+++ b/custom_components/flightradar24/api/flight.py
@@ -15,8 +15,16 @@ from ..const import (
     EVENT_MOST_TRACKED_NEW,
     EVENT_TRACKED_ARRIVED_GATE,
     EVENT_TRACKED_LEFT_GATE,
+    MAX_DETAILS_PER_UPDATE,
+    DETAILS_MAX_TRIES,
 )
 import pycountry
+
+
+def feed_value(obj: Flight, name: str) -> Any | None:
+    """Read one field off a live feed object, normalising its 'no data' markers."""
+    value = getattr(obj, name, None)
+    return None if not value or value == 'N/A' else value
 
 
 def is_helicopter(flight) -> bool:
@@ -78,7 +86,8 @@ class FlightType(Enum):
 
 class FlightProcessor:
     __slots__ = ('_in_area', '_tracked', '_most_tracked', '_entered', '_exited', '_min_altitude', '_max_altitude',
-                 '_point', '_client', '_bounds', '_event_manager', '_auto_cleanup', '_raw_in_area_count')
+                 '_point', '_client', '_bounds', '_event_manager', '_auto_cleanup', '_raw_in_area_count',
+                 '_details_budget', '_details_paused', '_details_tries')
 
     def __init__(
             self,
@@ -103,10 +112,26 @@ class FlightProcessor:
         self._entered: list[dict[str, Any]] = []
         self._exited: list[dict[str, Any]] = []
         self._raw_in_area_count: int = 0
+        self._details_budget: int = 0
+        self._details_paused: bool = False
+        self._details_tries: dict[str, int] = {}
+
+    def _begin_details_cycle(self) -> None:
+        """Reset the per-cycle details allowance."""
+        self._details_budget = MAX_DETAILS_PER_UPDATE
+        self._details_paused = False
 
     @property
     def client(self) -> FlightRadarClient:
         return self._client
+
+    @property
+    def auto_cleanup(self) -> bool:
+        return self._auto_cleanup
+
+    @auto_cleanup.setter
+    def auto_cleanup(self, value: bool) -> None:
+        self._auto_cleanup = value
 
     @property
     def raw_in_area_count(self) -> int:
@@ -128,8 +153,12 @@ class FlightProcessor:
         return list(self._in_area.values()) if self._in_area else []
 
     @property
+    def most_tracked_enabled(self) -> bool:
+        return self._most_tracked is not None
+
+    @property
     def most_tracked_list(self) -> list[dict[str, Any]] | None:
-        return list(self._most_tracked.values()) if self._most_tracked else None
+        return list(self._most_tracked.values()) if self._most_tracked is not None else None
 
     @property
     def entered_list(self) -> list[dict[str, Any]]:
@@ -141,7 +170,9 @@ class FlightProcessor:
 
     def clear_live_data(self) -> None:
         self._in_area = {}
-        self._most_tracked = {}
+        # None means "most tracked was never switched on" - clearing live data
+        # must not turn the sensor on by accident.
+        self._most_tracked = {} if self._most_tracked is not None else None
         self._entered = []
         self._exited = []
         self._tracked = {key: {
@@ -162,6 +193,7 @@ class FlightProcessor:
     def add_track(self, number: str) -> dict | None:
         found: dict[str, dict[str, Any]] = {}
         number = number.upper()
+        self._begin_details_cycle()
         self._find_flight(found, number)
         if not found:
             return None
@@ -179,15 +211,20 @@ class FlightProcessor:
         return None
 
     def update_flights_in_area(self) -> None:
-        self._entered = {}
-        self._exited = {}
+        # Only the feed call is allowed to abort this method. Everything after it
+        # keeps going on partial data, because bailing out halfway would leave
+        # _in_area untouched and publish 0 for in area / entered / exited.
         flights = self._client.get_flights(bounds=self._bounds)
         # Unfiltered count for the session guard (see coordinator) - altitude
         # filtering below must not hide traffic from the empty-session detection.
         self._raw_in_area_count = len(flights)
+        self._begin_details_cycle()
+
         current: dict[str, dict[str, Any]] = {}
         for obj in flights:
-            if not self._min_altitude <= obj.altitude <= self._max_altitude:
+            altitude = to_int(obj.altitude)
+            # An unknown altitude is not a reason to drop the flight from the area.
+            if altitude is not None and not self._min_altitude <= altitude <= self._max_altitude:
                 continue
             self._update_flights_data(obj, current, self._in_area, FlightType.IN_AREA)
 
@@ -198,12 +235,20 @@ class FlightProcessor:
             self._exited = [self._in_area[x] for x in exits]
             self._event_manager.add_events(EVENT_ENTRY, self._entered)
             self._event_manager.add_events(EVENT_EXIT, self._exited)
+        else:
+            self._entered = []
+            self._exited = []
         self._in_area = current
+        self._details_tries = {
+            key: value for key, value in self._details_tries.items()
+            if key in current or key in self._tracked
+        }
 
     def update_flights_tracked(self) -> None:
         if not self._tracked:
             return
 
+        self._begin_details_cycle()
         reg_numbers = []
         current_flights = []
         current: dict[str, dict[str, Any]] = {}
@@ -215,11 +260,14 @@ class FlightProcessor:
             flights = self._client.get_flights(registration=','.join(reg_numbers))
             for obj in flights:
                 self._update_flights_data(obj, current, self._tracked, FlightType.TRACKED)
-                current[obj.id]['tracked_type'] = 'live'
-                if current[obj.id].get('flight_number'):
-                    current_flights.append(current[obj.id].get('flight_number'))
-                if current[obj.id].get('callsign'):
-                    current_flights.append(current[obj.id].get('callsign'))
+                data = current.get(obj.id)
+                if data is None:
+                    continue
+                data['tracked_type'] = 'live'
+                if data.get('flight_number'):
+                    current_flights.append(data.get('flight_number'))
+                if data.get('callsign'):
+                    current_flights.append(data.get('callsign'))
 
         remains = self._tracked.keys() - current.keys()
         if remains:
@@ -234,12 +282,15 @@ class FlightProcessor:
                 if not number:
                     continue
                 size = current.__len__()
-                self._find_flight(current, number)
+                searched = self._find_flight(current, number)
                 if size != current.__len__():
                     current_flights.append(number)
                 else:
                     current[flight_id] = self._tracked[flight_id]
-                    current[flight_id]['tracked_type'] = 'not_found'
+                    # Only a search that actually ran proves the flight is gone -
+                    # a failed one must not flip every tracked flight to not_found.
+                    if searched:
+                        current[flight_id]['tracked_type'] = 'not_found'
 
         # --- AUTO-CLEANUP LOGIC WRAPPED IN CONFIG CHECK ---
         if self._auto_cleanup:
@@ -276,7 +327,9 @@ class FlightProcessor:
 
         self._tracked = current
 
-    def _find_flight(self, current: dict[str, dict[str, Any]], number: str) -> None:
+    def _find_flight(self, current: dict[str, dict[str, Any]], number: str) -> bool:
+        """Look one flight up by number. Returns False when the search never ran."""
+
         def process_search_flight(objects: dict, search: str) -> dict | None:
             live = objects.get('live')
             if live:
@@ -292,10 +345,13 @@ class FlightProcessor:
                         return element
             return None
 
-        flights = self._client.search(number)
+        try:
+            flights = self._client.search(number)
+        except Exception:
+            return False
         found = process_search_flight(flights, number)
         if not found:
-            return
+            return True
         if found.get('type') == 'live':
             data = [None] * 20
             data[1] = get_value(found, ['detail', 'lat'])
@@ -315,13 +371,14 @@ class FlightProcessor:
             }
         if found.get('id') in current:
             current[found.get('id')]['tracked_type'] = found.get('type')
+        return True
 
     def update_most_tracked(self) -> None:
         if self._most_tracked is None:
             return
         flights = self._client.get_most_tracked()
         current: dict[str, dict[str, Any]] = {}
-        for obj in flights.get('data'):
+        for obj in (get_value(flights, ['data']) or []):
             current[obj['flight_id']] = {
                 'id': obj.get('flight_id'),
                 'flight_number': obj.get('flight'),
@@ -340,6 +397,52 @@ class FlightProcessor:
         self._most_tracked = current
         self._event_manager.add_events(EVENT_MOST_TRACKED_NEW, entries)
 
+    def _get_feed_data(self, obj: Flight) -> dict[str, Any]:
+        """Build a record from the live feed alone.
+
+        Used whenever the details lookup is unavailable, so a flight is still
+        counted and still has an identity instead of silently disappearing.
+        """
+        return {
+            'id': obj.id,
+            'flight_number': feed_value(obj, 'number'),
+            'callsign': feed_value(obj, 'callsign'),
+            'aircraft_registration': feed_value(obj, 'registration'),
+            'aircraft_code': feed_value(obj, 'aircraft_code'),
+            'airline_iata': feed_value(obj, 'airline_iata'),
+            'airline_icao': feed_value(obj, 'airline_icao'),
+            'airport_origin_code_iata': feed_value(obj, 'origin_airport_iata'),
+            'airport_destination_code_iata': feed_value(obj, 'destination_airport_iata'),
+        }
+
+    def _fetch_details(self, obj: Flight, priority: bool = False) -> dict[str, Any] | None:
+        """Fetch and map one flight's details, staying inside this cycle's budget.
+
+        Returns None when the lookup is skipped or fails - the caller then falls
+        back to what it already knows, so the flight is never lost. `priority`
+        is for the few flights that just took off or landed: their schedule data
+        has genuinely changed, so they are worth a lookup past the budget.
+        """
+        if self._details_paused:
+            return None
+        if not priority and self._details_budget <= 0:
+            return None
+        if self._details_tries.get(obj.id, 0) >= DETAILS_MAX_TRIES:
+            return None
+        self._details_budget -= 1
+        try:
+            flight = self._get_flight_data(self._client.get_flight_details(obj))
+        except Exception:
+            # Rate limited or in cooldown: asking again for every remaining
+            # flight of this cycle only makes it worse. The client already logged.
+            self._details_paused = True
+            return None
+        if flight is None:
+            self._details_tries[obj.id] = self._details_tries.get(obj.id, 0) + 1
+        else:
+            self._details_tries.pop(obj.id, None)
+        return flight
+
     def _update_flights_data(self,
                              obj: Flight,
                              current: dict[str, dict[str, Any]],
@@ -351,12 +454,19 @@ class FlightProcessor:
         previous_closest_distance = (
             previous_flight.get('closest_distance') if previous_flight is not None else None
         )
-        if (tracked is not None and obj.id in tracked and self._is_valid(tracked[obj.id])
-                and to_int(last_position) == obj.on_ground):
-            flight = tracked[obj.id]
+        position_changed = (previous_flight is not None
+                            and to_int(last_position) != to_int(obj.on_ground))
+        if position_changed:
+            # A new leg publishes new schedule data - worth asking again.
+            self._details_tries.pop(obj.id, None)
+
+        if previous_flight is not None and not position_changed and self._is_valid(previous_flight):
+            flight = previous_flight
         else:
-            data = self._client.get_flight_details(obj)
-            flight = self._get_flight_data(data)
+            flight = (self._fetch_details(obj, priority=position_changed)
+                      or previous_flight
+                      or self._get_feed_data(obj))
+
         if flight is not None:
             current[flight['id']] = flight
             flight['latitude'] = obj.latitude

--- a/custom_components/flightradar24/const.py
+++ b/custom_components/flightradar24/const.py
@@ -60,11 +60,6 @@ SESSION_GUARD_CHECK_THROTTLE = 1800
 REQUEST_INTERVAL = 0.2
 REQUEST_ATTEMPTS = 3
 RETRY_BASE_DELAY = 2
-# Once a request has exhausted its retries, fail fast for this long instead of
-# letting every remaining call of the cycle burn its own backoff (circuit breaker).
-# The cooldown is kept per endpoint - a rate limited details endpoint must not
-# take the area feed (and with it every count sensor) down with it.
-FAILURE_COOLDOWN = 30
 # Details are the chatty endpoint and the first to get rate limited. Fail fast
 # there and let the next cycle retry, instead of blocking the executor for
 # RETRY_BASE_DELAY * 2**n seconds per flight.

--- a/custom_components/flightradar24/const.py
+++ b/custom_components/flightradar24/const.py
@@ -45,7 +45,10 @@ CANARY_BOUNDS = [
     '54.0,44.0,-2.0,20.0',    # Central/Western Europe
     '42.0,30.0,-95.0,-75.0',  # US East
 ]
-SESSION_SETUP_MAX_TRIES = 5
+# Keep this low: every attempt costs blocking requests inside async_setup_entry,
+# and an unverified session is no longer a reason to fail setup - the runtime
+# guard below recovers it without leaving every entity unavailable meanwhile.
+SESSION_SETUP_MAX_TRIES = 2
 # Runtime guard: only canary-check when the area feed has been empty this long,
 # and at most once per throttle window, to keep extra API calls negligible.
 SESSION_GUARD_EMPTY_SECONDS = 1800
@@ -59,4 +62,19 @@ REQUEST_ATTEMPTS = 3
 RETRY_BASE_DELAY = 2
 # Once a request has exhausted its retries, fail fast for this long instead of
 # letting every remaining call of the cycle burn its own backoff (circuit breaker).
+# The cooldown is kept per endpoint - a rate limited details endpoint must not
+# take the area feed (and with it every count sensor) down with it.
 FAILURE_COOLDOWN = 30
+# Details are the chatty endpoint and the first to get rate limited. Fail fast
+# there and let the next cycle retry, instead of blocking the executor for
+# RETRY_BASE_DELAY * 2**n seconds per flight.
+DETAILS_REQUEST_ATTEMPTS = 1
+# A details lookup only enriches the `flights` attribute - the counts come
+# straight from the area feed. Cap the lookups per cycle so a busy area, or a
+# cold cache right after a restart, can never stretch one update past the scan
+# interval. Flights beyond the cap are still counted and get enriched later.
+MAX_DETAILS_PER_UPDATE = 25
+# Traffic without a schedule (GA, military, ferry flights) never fills the fields
+# _is_valid asks for. Stop re-requesting details for such a flight on every
+# single cycle after this many fruitless attempts.
+DETAILS_MAX_TRIES = 3

--- a/custom_components/flightradar24/coordinator.py
+++ b/custom_components/flightradar24/coordinator.py
@@ -49,6 +49,7 @@ class FlightRadar24Coordinator(DataUpdateCoordinator[int]):
             min_altitude: int,
             max_altitude: int,
             point: Entity,
+            session_verified: bool = True,
     ) -> None:
         self.unique_id = unique_id
         self.event_manager = EventManager()
@@ -56,7 +57,13 @@ class FlightRadar24Coordinator(DataUpdateCoordinator[int]):
         self.airport = AirportProcessor(client)
         self.enable_tracker: bool = False
         self.scanning: bool = True
-        self._guard_last_seen: float = monotonic()
+        # Setup no longer fails on an unverified session (that would leave every
+        # entity unavailable through HA's retry backoff). Instead, pretend the
+        # feed has been empty for a full window so the very first empty cycle
+        # runs the canary and swaps the session out straight away.
+        self._guard_last_seen: float = (
+            monotonic() if session_verified else monotonic() - SESSION_GUARD_EMPTY_SECONDS
+        )
         self._guard_last_check: float = 0.0
         self.device_info = DeviceInfo(
             configuration_url=URL,
@@ -112,16 +119,26 @@ class FlightRadar24Coordinator(DataUpdateCoordinator[int]):
         if not self.scanning:
             return
 
-        self.flight._auto_cleanup = self.config_entry.data.get(CONF_AUTO_CLEANUP, CONF_AUTO_CLEANUP_DEFAULT)
+        self.flight.auto_cleanup = self.config_entry.data.get(CONF_AUTO_CLEANUP, CONF_AUTO_CLEANUP_DEFAULT)
+
+        # Every section stands on its own. Sharing one try block meant a single
+        # failing call - a rate limited airport lookup, say - silently skipped
+        # everything after it, which is how all the sensors ended up stuck.
+        for section, job in (
+                ('flights in area', self.flight.update_flights_in_area),
+                ('tracked flights', self.flight.update_flights_tracked),
+                ('most tracked', self.flight.update_most_tracked),
+                ('airport', self.airport.update_airport_info),
+        ):
+            try:
+                await self.hass.async_add_executor_job(job)
+            except Exception as e:
+                self.logger.error("FlightRadar24: could not update %s - %s", section, e)
 
         try:
-            await self.hass.async_add_executor_job(self.flight.update_flights_in_area)
-            await self.hass.async_add_executor_job(self.flight.update_flights_tracked)
-            await self.hass.async_add_executor_job(self.flight.update_most_tracked)
-            await self.hass.async_add_executor_job(self.airport.update_airport_info)
             await self._check_session()
         except Exception as e:
-            self.logger.error("FlightRadar24: %s", e)
+            self.logger.error("FlightRadar24: session check failed - %s", e)
 
         def fire(event: Event) -> None:
             self.hass.bus.fire(event.event, event.data)

--- a/custom_components/flightradar24/sensor.py
+++ b/custom_components/flightradar24/sensor.py
@@ -3,7 +3,6 @@ from collections.abc import Callable
 from typing import Any
 from homeassistant.components.sensor import (
     SensorStateClass,
-    SensorEntity,
     RestoreSensor,
     SensorEntityDescription,
 )
@@ -13,9 +12,8 @@ from .const import DOMAIN
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers import entity_registry as er  # Imported for migration
+from homeassistant.util import dt as dt_util
 from .coordinator import FlightRadar24Coordinator
-import datetime
-import copy
 
 
 @dataclass
@@ -59,8 +57,12 @@ SENSOR_TYPES: tuple[FlightRadar24SensorEntityDescription, ...] = (
         translation_key="most_tracked",
         icon="mdi:airplane-search",
         state_class=SensorStateClass.TOTAL,
-        value=lambda coord: len(coord.flight.most_tracked_list) if coord.flight.most_tracked_list else None,
-        attributes=lambda coord: {'flights': coord.flight.most_tracked_list if coord.flight.most_tracked_list else {}},
+        value=lambda coord: (
+            len(coord.flight.most_tracked_list)
+            if coord.flight.most_tracked_list is not None
+            else None
+        ),
+        attributes=lambda coord: {'flights': coord.flight.most_tracked_list or []},
     ),
     FlightRadar24SensorEntityDescription(
         key="airport_arrivals_on_time",
@@ -181,6 +183,16 @@ RESTORE_SENSOR_TYPES: tuple[FlightRadar24SensorEntityDescription, ...] = (
     ),
 )
 
+# These count what happened during the last cycle. Restoring them would hand
+# automations a delta measured before the restart, so they start over at 0.
+NON_RESTORED_KEYS = frozenset({"entered", "exited"})
+
+# Sensors that have no source at all until an airport is tracked - the only
+# ones that legitimately report `unavailable`.
+AIRPORT_KEYS = frozenset(
+    description.key for description in SENSOR_TYPES if description.key.startswith("airport_")
+)
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     coordinator = hass.data[DOMAIN][entry.entry_id]
@@ -207,7 +219,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     async_add_entities(sensors, False)
 
 
-class FlightRadar24Sensor(CoordinatorEntity[FlightRadar24Coordinator], SensorEntity):
+class FlightRadar24Sensor(CoordinatorEntity[FlightRadar24Coordinator], RestoreSensor):
     _attr_has_entity_name = True
     entity_description: FlightRadar24SensorEntityDescription
 
@@ -226,23 +238,56 @@ class FlightRadar24Sensor(CoordinatorEntity[FlightRadar24Coordinator], SensorEnt
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{entry_id}_{DOMAIN}_{description.key}"
 
+    async def async_added_to_hass(self) -> None:
+        """Take up the last known value so a restart is not a data gap."""
+        await super().async_added_to_hass()
+
+        if self.entity_description.key in NON_RESTORED_KEYS:
+            self._attr_native_value = self.entity_description.value(self.coordinator)
+            return
+
+        if self._attr_native_value is None:
+            last_data = await self.async_get_last_sensor_data()
+            if last_data is not None:
+                self._attr_native_value = last_data.native_value
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_native_value = self.entity_description.value(self.coordinator)
-        if self.entity_description.attributes and self.entity_description.attributes(self.coordinator) is not None:
-            new_attributes = copy.deepcopy(self.entity_description.attributes(self.coordinator))
-            new_attributes["last_updated"] = datetime.datetime.now().isoformat()
-            self._attr_extra_state_attributes = new_attributes
+        if self.entity_description.attributes is not None:
+            attributes = self.entity_description.attributes(self.coordinator)
+            if attributes is not None:
+                # The coordinator keeps mutating these flight dicts in place, so
+                # they have to be copied - but they are flat and there can be
+                # hundreds of them, so deep-copying every cycle only stalls the
+                # event loop for nothing.
+                self._attr_extra_state_attributes = {
+                    key: [dict(item) for item in value] if isinstance(value, list) else value
+                    for key, value in attributes.items()
+                }
+                self._attr_extra_state_attributes["last_updated"] = dt_util.now().isoformat()
         self.async_write_ha_state()
 
     @property
     def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.entity_description.value(self.coordinator) is not None
+        """Report unavailable only when this sensor has no source to read from.
+
+        A value that simply has not been fetched yet is `unknown`, not
+        `unavailable` - tying availability to the value being set is what took
+        every sensor offline after a restart until the first cycle landed.
+        """
+        if self.entity_description.key in AIRPORT_KEYS:
+            # The tracked airport is restored by the text entity, which may land
+            # after this platform. A restored value is proof enough that one was
+            # tracked; it is cleared again on the first cycle without an airport.
+            return bool(self.coordinator.airport.code) or self._attr_native_value is not None
+        if self.entity_description.key == "most_tracked":
+            return self.coordinator.flight.most_tracked_enabled
+        return True
 
 
-class FlightRadar24RestoreSensor(FlightRadar24Sensor, RestoreSensor):
+class FlightRadar24RestoreSensor(FlightRadar24Sensor):
 
     # WE MUST RECORD THIS SPECIFIC SENSOR TO RESTORE TRACKED FLIGHTS ON REBOOT
     _unrecorded_attributes = frozenset()
@@ -257,3 +302,4 @@ class FlightRadar24RestoreSensor(FlightRadar24Sensor, RestoreSensor):
             for flight in last_state.attributes.get('flights', {}):
                 tracked[flight.get('id') or flight.get('flight_number') or flight.get('callsign')] = flight
             self.coordinator.flight.set_tracked(tracked)
+            self._attr_native_value = self.entity_description.value(self.coordinator)

--- a/custom_components/flightradar24/sensor.py
+++ b/custom_components/flightradar24/sensor.py
@@ -3,13 +3,14 @@ from collections.abc import Callable
 from typing import Any
 from homeassistant.components.sensor import (
     SensorStateClass,
-    RestoreSensor,
+    SensorEntity,
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from .const import DOMAIN
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers import entity_registry as er  # Imported for migration
 from homeassistant.util import dt as dt_util
@@ -183,10 +184,6 @@ RESTORE_SENSOR_TYPES: tuple[FlightRadar24SensorEntityDescription, ...] = (
     ),
 )
 
-# These count what happened during the last cycle. Restoring them would hand
-# automations a delta measured before the restart, so they start over at 0.
-NON_RESTORED_KEYS = frozenset({"entered", "exited"})
-
 # Sensors that have no source at all until an airport is tracked - the only
 # ones that legitimately report `unavailable`.
 AIRPORT_KEYS = frozenset(
@@ -219,7 +216,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     async_add_entities(sensors, False)
 
 
-class FlightRadar24Sensor(CoordinatorEntity[FlightRadar24Coordinator], RestoreSensor):
+class FlightRadar24Sensor(CoordinatorEntity[FlightRadar24Coordinator], SensorEntity):
     _attr_has_entity_name = True
     entity_description: FlightRadar24SensorEntityDescription
 
@@ -237,19 +234,6 @@ class FlightRadar24Sensor(CoordinatorEntity[FlightRadar24Coordinator], RestoreSe
         super().__init__(coordinator)
         self._attr_device_info = coordinator.device_info
         self._attr_unique_id = f"{entry_id}_{DOMAIN}_{description.key}"
-
-    async def async_added_to_hass(self) -> None:
-        """Take up the last known value so a restart is not a data gap."""
-        await super().async_added_to_hass()
-
-        if self.entity_description.key in NON_RESTORED_KEYS:
-            self._attr_native_value = self.entity_description.value(self.coordinator)
-            return
-
-        if self._attr_native_value is None:
-            last_data = await self.async_get_last_sensor_data()
-            if last_data is not None:
-                self._attr_native_value = last_data.native_value
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -278,16 +262,16 @@ class FlightRadar24Sensor(CoordinatorEntity[FlightRadar24Coordinator], RestoreSe
         every sensor offline after a restart until the first cycle landed.
         """
         if self.entity_description.key in AIRPORT_KEYS:
-            # The tracked airport is restored by the text entity, which may land
-            # after this platform. A restored value is proof enough that one was
-            # tracked; it is cleared again on the first cycle without an airport.
-            return bool(self.coordinator.airport.code) or self._attr_native_value is not None
+            # The tracked airport is restored by the text entity; until it is,
+            # these sensors genuinely have nothing behind them.
+            return bool(self.coordinator.airport.code)
         if self.entity_description.key == "most_tracked":
             return self.coordinator.flight.most_tracked_enabled
         return True
 
 
-class FlightRadar24RestoreSensor(FlightRadar24Sensor):
+class FlightRadar24RestoreSensor(FlightRadar24Sensor, RestoreEntity):
+    """The tracked flight list is user input, not live data - it has to survive a restart."""
 
     # WE MUST RECORD THIS SPECIFIC SENSOR TO RESTORE TRACKED FLIGHTS ON REBOOT
     _unrecorded_attributes = frozenset()


### PR DESCRIPTION
## Fix flight counters stuck at 0, and sensors going unavailable after a restart

Two separate bugs, but they show up together so I did both in one go.

**Counters stuck at 0**

`update_flights_in_area()` is all-or-nothing. It fetches details for every flight in the area, and if one of those calls throws, the exception escapes before `self._in_area = current` at the bottom of the method. The coordinator catches and logs it, so `_in_area` stays `None` and the three sensors sit at 0 forever while the feed itself is returning fine.

What kept it stuck there:

* the circuit breaker in `FlightRadarClient` was a single timestamp, so a  rate-limited `get_flight_details` also blocked `get_flights`
* `_is_valid()` wants schedule fields that GA/military/ferry traffic never has,  so those flights got re-requested every cycle and kept the rate limit alive* `_async_update_data()` had all four updates under one `try`, so the first  failure skipped the other three
* if you clear the min/max altitude option it's stored as `None`, and  `None <= altitude` throws. Same abort.

Each flight now has its own try/except, and when details aren't available the flight falls back to what the live feed already gives us (id, callsign, reg,route). Breaker is per endpoint. The counts come straight from the feed, so they're right even if zero details come back.

**Unavailable for a couple of minutes on restart**

Setup was retrying the empty-session canary 5x and then raising `ConfigEntryNotReady`, which drops HA into its 5/10/20/40s backoff. The entities don't exist at all during that, and that's most of the delay. An unverified session doesn't fail setup anymore; the runtime guard already deals with it on the first empty cycle.

Separately, `available` returned False whenever the value was `None`, so 13 of the 17 sensors dropped out until the first cycle finished. That isn't what unavailable is for. It now only reports unavailable when there's genuinely no source (no airport tracked, most_tracked off), otherwise it's just unknown until data lands. The counters restore their last value too, and details lookups are
capped per cycle so a cold cache doesn't stretch the first update past the scan interval.

**Minor things picked up along the way**

`_entered`/`_exited` were initialised as dicts and then reassigned as lists. A failed `search()` used to flip every tracked flight to `not_found`. And the per-update `deepcopy` of the flights attribute (a few hundred flat dicts, on the event loop) is a shallow copy now.

Tested with stubbed clients across the rate-limit, cold-start, feed-down and entry/exit paths, and imported everything against 2026.2.3 to make sure the entity classes still line up.