### PR TITLE
Harden the details-first update path

### DIFF
--- a/custom_components/flightradar24/api/client.py
+++ b/custom_components/flightradar24/api/client.py
@@ -3,20 +3,25 @@ from ..const import (
     REQUEST_INTERVAL,
     REQUEST_ATTEMPTS,
     RETRY_BASE_DELAY,
+    FAILURE_COOLDOWN,
+    DETAILS_REQUEST_ATTEMPTS,
 )
 from logging import Logger
 from threading import Lock
 from time import sleep, monotonic
 
+GLOBAL_COOLDOWN_KEY = '*'
+
 
 class FlightRadarClient:
-    __slots__ = ('_client', '_logger', '_last_request', '_lock')
+    __slots__ = ('_client', '_logger', '_last_request', '_lock', '_broken_until')
 
     def __init__(self, client: FlightRadar24API, logger: Logger) -> None:
         self._client = client
         self._logger = logger
         self._last_request: float = 0.0
         self._lock = Lock()
+        self._broken_until: dict[str, float] = {}
 
     def get_airport_details(self, code: str) -> dict:
         return self._request('get_airport_details', code)
@@ -25,7 +30,7 @@ class FlightRadarClient:
         return self._request('get_flights', **kwargs)
 
     def get_flight_details(self, obj: Flight) -> dict:
-        return self._request('get_flight_details', obj)
+        return self._request('get_flight_details', obj, attempts=DETAILS_REQUEST_ATTEMPTS)
 
     def search(self, number: str) -> dict:
         return self._request('search', number)
@@ -33,8 +38,13 @@ class FlightRadarClient:
     def get_most_tracked(self) -> dict:
         return self._request('get_most_tracked')
 
-    def _request(self, method_name: str, *args, **kwargs) -> dict:
-        for attempt in range(REQUEST_ATTEMPTS):
+    def _request(self, method_name: str, *args, attempts: int = REQUEST_ATTEMPTS, **kwargs) -> dict:
+        cooldown = max(self._broken_until.get(method_name, 0.0),
+                       self._broken_until.get(GLOBAL_COOLDOWN_KEY, 0.0))
+        if monotonic() < cooldown:
+            raise ConnectionError('{} is in cooldown after repeated failures'.format(method_name))
+
+        for attempt in range(attempts):
             # Hold the lock only for the spacing gate, not the HTTP call,
             # so a slow request does not serialize the other callers.
             with self._lock:
@@ -45,11 +55,21 @@ class FlightRadarClient:
 
             try:
                 method = getattr(self._client, method_name)
-                return method(*args, **kwargs)
+                result = method(*args, **kwargs)
             except Exception as e:
-                if attempt == REQUEST_ATTEMPTS - 1:
+                if attempt == attempts - 1:
+                    # 429/403 are endpoint-specific on FR24 (different hosts,
+                    # see #271) and must not take the working feed down with
+                    # them; anything else is treated as a global outage.
+                    message = str(e)
+                    key = method_name if ('429' in message or '403' in message) else GLOBAL_COOLDOWN_KEY
+                    self._broken_until[key] = monotonic() + FAILURE_COOLDOWN
                     self._logger.warning('FlightRadar24: Could not get details for %s - %s', method_name, e)
                     raise e
                 sleep(RETRY_BASE_DELAY * (2 ** attempt))
+            else:
+                self._broken_until.pop(method_name, None)
+                self._broken_until.pop(GLOBAL_COOLDOWN_KEY, None)
+                return result
 
         return None

--- a/custom_components/flightradar24/api/flight.py
+++ b/custom_components/flightradar24/api/flight.py
@@ -17,6 +17,7 @@ from ..const import (
     EVENT_MOST_TRACKED_NEW,
     EVENT_TRACKED_ARRIVED_GATE,
     EVENT_TRACKED_LEFT_GATE,
+    DETAILS_MAX_TRIES,
 )
 import pycountry
 
@@ -89,7 +90,8 @@ class FlightType(Enum):
 
 class FlightProcessor:
     __slots__ = ('_in_area', '_tracked', '_most_tracked', '_entered', '_exited', '_min_altitude', '_max_altitude',
-                 '_point', '_client', '_bounds', '_event_manager', '_auto_cleanup', '_raw_in_area_count')
+                 '_point', '_client', '_bounds', '_event_manager', '_auto_cleanup', '_raw_in_area_count',
+                 '_details_paused', '_details_tries')
 
     def __init__(
             self,
@@ -114,6 +116,8 @@ class FlightProcessor:
         self._entered: list[dict[str, Any]] = []
         self._exited: list[dict[str, Any]] = []
         self._raw_in_area_count: int = 0
+        self._details_paused: bool = False
+        self._details_tries: dict[str, int] = {}
 
     @property
     def client(self) -> FlightRadarClient:
@@ -200,6 +204,7 @@ class FlightProcessor:
     def update_flights_in_area(self) -> None:
         self._entered = []
         self._exited = []
+        self._details_paused = False
         flights = self._client.get_flights(bounds=self._bounds)
         # Unfiltered count for the session guard (see coordinator) - altitude
         # filtering below must not hide traffic from the empty-session detection.
@@ -228,10 +233,14 @@ class FlightProcessor:
                         self._entered.append(flight)
                         self._event_manager.add_event(EVENT_ENTRY, flight)
 
+        self._details_tries = {key: value for key, value in self._details_tries.items()
+                               if key in self._in_area or key in self._tracked}
+
     def update_flights_tracked(self) -> None:
         if not self._tracked:
             return
 
+        self._details_paused = False
         current_flights = []
         flight_ids = set(self._tracked.keys())
         reg_to_id = {f.get('aircraft_registration'): f.get('id') for f in self._tracked.values() if
@@ -442,12 +451,37 @@ class FlightProcessor:
             last_position = None
             previous_closest_distance = None
 
+        if is_same_flight and to_int(last_position) != to_int(obj.on_ground):
+            # A new leg publishes new schedule data - the lookup cap starts over.
+            self._details_tries.pop(obj.id, None)
+
         if (is_same_flight and self._is_valid(previous)
                 and to_int(last_position) == obj.on_ground):
             flight = previous
+        elif self._details_paused or self._details_tries.get(obj.id, 0) >= DETAILS_MAX_TRIES:
+            # The details endpoint is unhappy this cycle, or this flight has
+            # provably nothing more to give - keep what exists instead of
+            # asking again.
+            flight = previous if is_same_flight else None
         else:
-            data = self._client.get_flight_details(obj)
-            flight = self._get_flight_data(data)
+            try:
+                data = self._client.get_flight_details(obj)
+            except Exception:
+                # One failed lookup pauses the rest of this cycle - hammering
+                # a rate limited endpoint once per flight only keeps it limited.
+                # The client already logged; known flights keep their record.
+                self._details_paused = True
+                flight = previous if is_same_flight else None
+            else:
+                flight = self._get_flight_data(data)
+                if flight is None or not self._is_valid(flight):
+                    # Fruitless also covers a lookup that succeeded but stays
+                    # schedule-less (GA, military, ferry) - cap the re-requests.
+                    self._details_tries[obj.id] = self._details_tries.get(obj.id, 0) + 1
+                else:
+                    self._details_tries.pop(obj.id, None)
+                if flight is None and is_same_flight:
+                    flight = previous
         if flight is not None:
             flight['latitude'] = obj.latitude
             flight['longitude'] = obj.longitude

--- a/custom_components/flightradar24/const.py
+++ b/custom_components/flightradar24/const.py
@@ -60,6 +60,15 @@ REQUEST_ATTEMPTS = 3
 RETRY_BASE_DELAY = 2
 # Once a request has exhausted its retries, fail fast for this long instead of
 # letting every remaining call of the cycle burn its own backoff (circuit breaker).
-# The cooldown is kept per endpoint - a rate limited details endpoint must not
-# take the area feed (and with it every count sensor) down with it.
+# HTTP 429/403 are endpoint-specific on FR24 (feed, details and most-tracked
+# live on different hosts - see #271), so those cool down per endpoint;
+# connection-level failures affect everything and cool down globally.
 FAILURE_COOLDOWN = 30
+# Details are the chatty endpoint and the first to get rate limited. One attempt,
+# no backoff - a failed lookup pauses further lookups for the running cycle and
+# the next cycle retries anyway.
+DETAILS_REQUEST_ATTEMPTS = 1
+# Traffic whose details stay schedule-less (GA, military, ferry flights) never
+# passes _is_valid. Stop re-requesting details for such a flight after this many
+# fruitless lookups; a takeoff/landing starts the count over for the new leg.
+DETAILS_MAX_TRIES = 3


### PR DESCRIPTION
Keeps the v2 philosophy (flights enter the area list only with full details, so events stay automation-safe) and fixes the degraded path:

- A failed details lookup no longer aborts update_flights_in_area halfway through a partially mutated area list. It pauses further lookups for the running cycle; known flights keep their record, new flights simply enter on the next healthy cycle.
- Schedule-less traffic (GA, military, ferry) stops being re-requested on every cycle after DETAILS_MAX_TRIES fruitless lookups; a takeoff/landing resets the cap for the new leg.
- get_flight_details uses a single attempt without backoff - the next cycle retries anyway, and 6 s of backoff per flight is what stretched cold starts.
- The failure cooldown is back as a hybrid: HTTP 429/403 cool down per endpoint (they are endpoint-specific on FR24, see #271 - a limited details endpoint must not take the working feed down), while connection-level failures cool everything down globally.