### PR TITLE
Card: optional show_home marker at the centre of the observed area

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ template:
 ```
 
 ### <a id="flightradar24-card">Flightradar24 Map Card</a>
-Built-in Lovelace card with an OpenStreetMap of your monitored area, aircraft markers, optional flight tracks, and a list of flights currently in the area.
+Built-in Lovelace card with an OpenStreetMap of your monitored area, aircraft markers, optional flight tracks, an optional marker at the centre of the area, and a list of flights currently in the area.
 
 The card is registered automatically when the integration is loaded — no manual Lovelace resource setup is required.
 
@@ -384,6 +384,7 @@ entity: sensor.flightradar24_current_in_area
 title: Flights Nearby
 show_flights: true
 show_tracks: true
+show_home: true
 ```
 
 #### Configuration options
@@ -394,6 +395,7 @@ show_tracks: true
 | `title` | string | — | Optional card title |
 | `show_flights` | boolean | `true` | Show the flights list under the map |
 | `show_tracks` | boolean | `true` | Draw flight tracks on the map from each flight's `coordinates` history |
+| `show_home` | boolean | `false` | Mark the centre of the observed area — the latitude/longitude this device is configured with |
 
 ### <a id="lovelace">Lovelace Card</a>
 You can add flight table to your [Home Assistant dashboard](https://www.home-assistant.io/dashboards/)

--- a/custom_components/flightradar24/frontend/flightradar24-card.js
+++ b/custom_components/flightradar24/frontend/flightradar24-card.js
@@ -75,6 +75,8 @@ class Flightradar24Card extends HTMLElement {
     this._markers = null;
     this._tracks = null;
     this._areaRect = null;
+    this._homeMarker = null;
+    this._homeMarkerPos = null;
     this._markerById = new Map();
     this._selectedFlightId = null;
     this._openPopupFlightId = null;
@@ -95,6 +97,7 @@ class Flightradar24Card extends HTMLElement {
     this._config = {
       show_flights: true,
       show_tracks: true,
+      show_home: false,
       ...config,
     };
     if (prev && prev.entity !== this._config.entity) {
@@ -162,6 +165,8 @@ class Flightradar24Card extends HTMLElement {
     this._markers = null;
     this._tracks = null;
     this._areaRect = null;
+    this._homeMarker = null;
+    this._homeMarkerPos = null;
     this._markerById = new Map();
     this._selectedFlightId = null;
     this._openPopupFlightId = null;
@@ -472,6 +477,24 @@ class Flightradar24Card extends HTMLElement {
         height: 26px;
         fill: currentColor;
       }
+      .home-icon {
+        background: transparent;
+        border: none;
+      }
+      .home-marker {
+        width: 24px;
+        height: 24px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--error-color, #e53935);
+        filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.45));
+      }
+      .home-marker svg {
+        width: 22px;
+        height: 22px;
+        fill: currentColor;
+      }
       .leaflet-popup-content {
         margin: 8px 10px;
         font-size: 0.85rem;
@@ -604,6 +627,56 @@ class Flightradar24Card extends HTMLElement {
         </div>
       `,
     });
+  }
+
+  _homeIcon(L) {
+    return L.divIcon({
+      className: "home-icon",
+      iconSize: [24, 24],
+      iconAnchor: [12, 12],
+      html: `
+        <div class="home-marker">
+          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
+          </svg>
+        </div>
+      `,
+    });
+  }
+
+  /**
+   * Marker at the centre of the observed area - the latitude/longitude this
+   * device is configured with. Deliberately not zone.home: with several
+   * Flightradar24 devices watching different points, only the bounds centre
+   * is correct for the device this card is showing.
+   */
+  _syncHomeMarker(L, map, parsed) {
+    if (this._config.show_home !== true) {
+      if (this._homeMarker) {
+        map.removeLayer(this._homeMarker);
+        this._homeMarker = null;
+        this._homeMarkerPos = null;
+      }
+      return;
+    }
+    // parsed is non-null and numeric here: _parseBounds rejects both, and
+    // _syncMap is not reached otherwise.
+    const posKey = `${parsed.lat},${parsed.lon}`;
+    if (this._homeMarker) {
+      if (posKey !== this._homeMarkerPos) {
+        this._homeMarker.setLatLng([parsed.lat, parsed.lon]);
+        this._homeMarkerPos = posKey;
+      }
+      return;
+    }
+    this._homeMarker = L.marker([parsed.lat, parsed.lon], {
+      icon: this._homeIcon(L),
+      keyboard: false,
+      // Above aircraft: a fixed reference point should stay findable inside
+      // a dense cluster of markers.
+      zIndexOffset: 1000,
+    }).addTo(map);
+    this._homeMarkerPos = posKey;
   }
 
   _flightId(flight) {
@@ -800,6 +873,8 @@ class Flightradar24Card extends HTMLElement {
       [parsed.south, parsed.west],
       [parsed.north, parsed.east]
     );
+
+    this._syncHomeMarker(L, map, parsed);
 
     const boundsKey = `${parsed.south},${parsed.west},${parsed.north},${parsed.east}`;
     if (boundsKey !== this._lastBoundsKey) {
@@ -1121,6 +1196,10 @@ class Flightradar24CardEditor extends HTMLElement {
         <input type="checkbox" id="show_tracks" ${this._config.show_tracks !== false ? "checked" : ""} />
         <span>Show flight tracks</span>
       </div>
+      <div class="row check">
+        <input type="checkbox" id="show_home" ${this._config.show_home === true ? "checked" : ""} />
+        <span>Show home marker</span>
+      </div>
     `;
 
     const mount = this.shadowRoot.getElementById("entity-picker");
@@ -1161,6 +1240,13 @@ class Flightradar24CardEditor extends HTMLElement {
       this._fireConfigChanged({
         ...this._config,
         show_tracks: event.target.checked,
+      });
+    });
+
+    this.shadowRoot.getElementById("show_home").addEventListener("change", (event) => {
+      this._fireConfigChanged({
+        ...this._config,
+        show_home: event.target.checked,
       });
     });
   }


### PR DESCRIPTION
## What

Adds an optional `show_home` option to the Flightradar24 map card that marks the centre of the observed area.

The card already draws the area rectangle, but nothing marks the point that area is centred on, so there's no visual reference for where you are relative to the traffic. That matters most when the radius is large enough to reach a nearby airport — the marker cluster sits over the field and it isn't obvious how far away it actually is.

```yaml
type: custom:flightradar24-card
entity: sensor.flightradar24_current_in_area
show_home: true
```

## Design choices

**Default `false`.** Existing dashboards render exactly as before — this is purely additive. Happy to flip it to `true` if you'd rather it be on by default; it's a one-line change.

**Position comes from the sensor's `bounds` centre, not `zone.home`.** With more than one Flightradar24 device watching different points, `zone.home` would be wrong for every card except the one showing the home device. The bounds centre is always the latitude/longitude the device that card is showing was configured with.

**Follows the card's existing conventions** rather than inventing new ones:
- a `divIcon` with an inline SVG path, styled from the card stylesheet the same way `.ac-marker` is
- added to the map directly, like `_areaRect` (not into the `_markers` layer group, which is rebuilt per flight update)
- cleared in `_destroyMap` alongside `_areaRect`
- guarded against per-tick churn with a position key, in the same spirit as `_lastBoundsKey` and `_frHeading` — the marker is only moved when the bounds centre actually changes

**Drawn above aircraft** (`zIndexOffset: 1000`) so a fixed reference point stays findable inside a dense cluster.

No new translation strings: the editor's existing labels are hardcoded English, so "Show home marker" matches.

## Testing

Verified on Home Assistant 2026.7.4 with the integration at v2.0.1, by running the patched card on a live instance:

- `show_home` omitted → no marker (existing configs unaffected)
- `show_home: false` → no marker
- `show_home: true` → marker at the area centre
- toggling the option on a live card in both directions adds/removes exactly one Leaflet layer, with no accumulation across repeated sensor updates
- repeated updates with an unchanged centre don't move or duplicate the marker
- changing the card's entity to one without a `bounds` attribute and back leaves exactly one marker
- editor: the checkbox appears unchecked when the option is unset, emits `show_home: true` on change, and reflects an existing `show_home: true` as checked
- no page errors from the card during any of the above

Not exercised directly: the `_destroyMap` reset on disconnect/reconnect. That line mirrors the existing `_areaRect` handling in the same function.
